### PR TITLE
Add Issue #2: initial SQL migration (001_init.sql) for Supabase schema

### DIFF
--- a/packages/db/migrations/001_init.sql
+++ b/packages/db/migrations/001_init.sql
@@ -1,0 +1,37 @@
+CREATE EXTENSION IF NOT EXISTS "pgcrypto";
+
+CREATE TABLE users (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  email TEXT NOT NULL UNIQUE,
+  credits_remaining INTEGER NOT NULL DEFAULT 0,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE TABLE videos (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  status TEXT NOT NULL DEFAULT 'queued',
+  source_url TEXT NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE TABLE jobs (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  video_id UUID NOT NULL REFERENCES videos(id) ON DELETE CASCADE,
+  status TEXT NOT NULL DEFAULT 'pending',
+  error_message TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE TABLE payments (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  amount_cents INTEGER NOT NULL,
+  currency TEXT NOT NULL DEFAULT 'usd',
+  status TEXT NOT NULL DEFAULT 'pending',
+  provider_reference TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX videos_user_id_idx ON videos(user_id);
+CREATE INDEX jobs_video_id_idx ON jobs(video_id);


### PR DESCRIPTION
### Motivation
- Implement Issue #2 by providing a minimal, production-ready Supabase/Postgres migration that initializes the core schema for the project.
- Ensure all tables use UUID primary keys, include timestamping, and have the necessary foreign keys and indexes for expected query patterns.
- Keep the schema small and avoid RLS, triggers, or functions as required by the project constraints.

### Description
- Added migration file `packages/db/migrations/001_init.sql` that enables the `pgcrypto` extension and uses `gen_random_uuid()` for UUID primary keys.
- Created `users`, `videos`, `jobs`, and `payments` tables with `created_at TIMESTAMPTZ NOT NULL DEFAULT now()` on each table and minimal necessary columns.
- Added foreign keys with `ON DELETE CASCADE` for `videos.user_id -> users.id`, `jobs.video_id -> videos.id`, and `payments.user_id -> users.id`.
- Created indexes `videos_user_id_idx` on `videos(user_id)` and `jobs_video_id_idx` on `jobs(video_id)` and did not add any RLS policies, triggers, or functions.

### Testing
- Verified the migration file contents with `sed -n '1,240p' packages/db/migrations/001_init.sql`, which printed the full migration and succeeded.
- Displayed the file with line numbers using `nl -ba packages/db/migrations/001_init.sql` to confirm file length and structure, which succeeded.
- Confirmed the new migration is present in the repository file list using `rg --files` / project file listing, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a04ba32c8c8331932d988fe5547305)