### PR TITLE
Add migration 002: index for payments.user_id

### DIFF
--- a/packages/db/migrations/002_add_indexes.sql
+++ b/packages/db/migrations/002_add_indexes.sql
@@ -1,0 +1,1 @@
+CREATE INDEX payments_user_id_idx ON payments(user_id);


### PR DESCRIPTION
### Motivation
- Add the missing index on the `payments.user_id` foreign key as a forward-only migration while keeping the change minimal and leaving `001_init.sql` untouched.

### Description
- Added a new migration file `packages/db/migrations/002_add_indexes.sql` containing `CREATE INDEX payments_user_id_idx ON payments(user_id);` and no other codebase modifications.

### Testing
- Ran `nl -ba packages/db/migrations/002_add_indexes.sql` and `git status --short` to verify the file contents and presence in the working tree (succeeded), and attempted `curl -I https://www.postgresql.org/docs/current/sql-createindex.html` which returned HTTP 403 from the environment (external docs check failed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a14f52c17c8331ab0eaa4065416d97)