### PR TITLE
feat(db): enable RLS and add per-user access policies

### DIFF
--- a/packages/db/migrations/003_enable_rls_and_policies.sql
+++ b/packages/db/migrations/003_enable_rls_and_policies.sql
@@ -1,0 +1,48 @@
+ALTER TABLE public.users ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.videos ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.jobs ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.payments ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY users_select_own
+  ON public.users
+  FOR SELECT
+  USING (id = auth.uid());
+
+CREATE POLICY users_update_own
+  ON public.users
+  FOR UPDATE
+  USING (id = auth.uid())
+  WITH CHECK (id = auth.uid());
+
+CREATE POLICY videos_select_own
+  ON public.videos
+  FOR SELECT
+  USING (user_id = auth.uid());
+
+CREATE POLICY videos_insert_own
+  ON public.videos
+  FOR INSERT
+  WITH CHECK (user_id = auth.uid());
+
+CREATE POLICY videos_update_own
+  ON public.videos
+  FOR UPDATE
+  USING (user_id = auth.uid())
+  WITH CHECK (user_id = auth.uid());
+
+CREATE POLICY payments_select_own
+  ON public.payments
+  FOR SELECT
+  USING (user_id = auth.uid());
+
+CREATE POLICY jobs_select_own
+  ON public.jobs
+  FOR SELECT
+  USING (
+    EXISTS (
+      SELECT 1
+      FROM public.videos
+      WHERE videos.id = jobs.video_id
+        AND videos.user_id = auth.uid()
+    )
+  );


### PR DESCRIPTION
### Motivation
- Harden database security by enabling Row Level Security and strict per-user policies on `users`, `videos`, `jobs`, and `payments` to enforce data isolation before implementing credits, payments, and video pipelines.

### Description
- Added a migration at `packages/db/migrations/003_enable_rls_and_policies.sql` that enables RLS on `public.users`, `public.videos`, `public.jobs`, and `public.payments`.
- Added policies so `users` allow `SELECT` and `UPDATE` only when `id = auth.uid()`.
- Added policies so `videos` allow `SELECT`, `INSERT`, and `UPDATE` only when `user_id = auth.uid()`, `payments` allow `SELECT` only when `user_id = auth.uid()` (no client `INSERT` policy), and `jobs` allow `SELECT` only when the related `video_id` belongs to the current user via an `EXISTS` subquery against `videos`.
- No prior migrations or schema/table structures were modified and SQL is kept explicit and self-contained in the new migration file.

### Testing
- Ran `git diff --check HEAD~1 HEAD && git status --short` which returned no issues (success).
- Inspected the migration contents with `sed -n` and `nl -ba` to verify the SQL was written as intended (success).
- Attempted an external `curl` check which failed due to network/proxy restrictions in the environment and does not reflect the migration correctness (network check failed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a29b1c9a948331bccc24b9750836c7)