### PR TITLE
Follow-up: implement migration 004 for secure credit functions

### DIFF
--- a/packages/db/migrations/004_secure_credit_system.sql
+++ b/packages/db/migrations/004_secure_credit_system.sql
@@ -1,0 +1,65 @@
+DROP POLICY IF EXISTS users_update_own ON public.users;
+
+CREATE OR REPLACE FUNCTION public.deduct_credits(amount integer)
+RETURNS integer
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  updated_credits integer;
+BEGIN
+  IF auth.uid() IS NULL THEN
+    RAISE EXCEPTION 'Authentication required';
+  END IF;
+
+  IF amount IS NULL OR amount <= 0 THEN
+    RAISE EXCEPTION 'Amount must be greater than zero';
+  END IF;
+
+  UPDATE public.users
+  SET credits_remaining = credits_remaining - amount
+  WHERE id = auth.uid()
+    AND credits_remaining >= amount
+  RETURNING credits_remaining INTO updated_credits;
+
+  IF updated_credits IS NULL THEN
+    RAISE EXCEPTION 'Insufficient credits';
+  END IF;
+
+  RETURN updated_credits;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.add_credits(user_id uuid, amount integer)
+RETURNS integer
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  updated_credits integer;
+BEGIN
+  IF amount IS NULL OR amount <= 0 THEN
+    RAISE EXCEPTION 'Amount must be greater than zero';
+  END IF;
+
+  UPDATE public.users
+  SET credits_remaining = credits_remaining + amount
+  WHERE id = user_id
+  RETURNING credits_remaining INTO updated_credits;
+
+  IF updated_credits IS NULL THEN
+    RAISE EXCEPTION 'User not found';
+  END IF;
+
+  RETURN updated_credits;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.deduct_credits(integer) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.add_credits(uuid, integer) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.add_credits(uuid, integer) FROM authenticated;
+
+GRANT EXECUTE ON FUNCTION public.deduct_credits(integer) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.add_credits(uuid, integer) TO service_role;


### PR DESCRIPTION
### Motivation

- Prevent authenticated users from directly modifying `credits_remaining` and limit credit mutations to secure, auditable procedures.
- Provide an atomic, role-restricted debit operation for frontend usage and a service-only credit-topup operation for trusted services.
- Implement these changes entirely via a new migration so schema and prior migrations remain unchanged.

### Description

- Drop the `users_update_own` RLS policy so authenticated sessions cannot perform direct `UPDATE` on `public.users` via `packages/db/migrations/004_secure_credit_system.sql`.
- Add `public.deduct_credits(amount integer)` as a `SECURITY DEFINER` PL/pgSQL function that requires authentication, validates positive amounts, atomically deducts only when `credits_remaining >= amount`, and raises on insufficient credits.
- Add `public.add_credits(user_id uuid, amount integer)` as a `SECURITY DEFINER` PL/pgSQL function that validates positive amounts, increments a specified user's credits, and raises if the target user is not found.
- Revoke public execution on both functions and grant `EXECUTE` to `authenticated` for `deduct_credits(integer)` and to `service_role` for `add_credits(uuid, integer)`.

### Testing

- Verified current RLS and policies file via `sed -n '1,260p' packages/db/migrations/003_enable_rls_and_policies.sql` and confirmed the existing policies referenced the prior `users_update_own` policy (succeeded). 
- Verified the new migration file contents via `sed -n '1,260p' packages/db/migrations/004_secure_credit_system.sql` and `nl -ba packages/db/migrations/004_secure_credit_system.sql` to ensure functions and grants match the specification (succeeded).
- Generated the follow-up PR description via the repository PR helper tool to summarize the migration changes (succeeded).
- Attempted to fetch external PostgreSQL docs via `curl` for reference but the request returned HTTP 403 in this environment (failed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a2a3b4ec608331bd53a17f7fec1578)