### PR TITLE
feat(db): stripe payment foundation migration (005) — idempotent webhook support

### DIFF
--- a/packages/db/migrations/005_stripe_payment_foundation.sql
+++ b/packages/db/migrations/005_stripe_payment_foundation.sql
@@ -1,0 +1,30 @@
+CREATE TYPE public.payment_status AS ENUM (
+  'pending',
+  'succeeded',
+  'failed',
+  'refunded'
+);
+
+CREATE TABLE public.payment_events (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL REFERENCES public.users(id) ON DELETE CASCADE,
+  provider TEXT NOT NULL DEFAULT 'stripe',
+  provider_reference TEXT NOT NULL,
+  amount_cents INTEGER NOT NULL,
+  currency TEXT NOT NULL,
+  status public.payment_status NOT NULL,
+  raw_payload JSONB,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  UNIQUE (provider, provider_reference)
+);
+
+ALTER TABLE public.payment_events ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY payment_events_select_own
+  ON public.payment_events
+  FOR SELECT
+  USING (user_id = auth.uid());
+
+REVOKE ALL ON TABLE public.payment_events FROM PUBLIC;
+GRANT SELECT ON TABLE public.payment_events TO authenticated;
+GRANT INSERT ON TABLE public.payment_events TO service_role;


### PR DESCRIPTION
### Motivation

- Prepare database infrastructure to safely record Stripe webhook events and prevent double-crediting from retries.
- Ensure only backend/service credentials can insert payment events while clients can only read their own records.
- Provide a typed status field for payments to enable reliable payment tracking and state transitions.

### Description

- Adds `packages/db/migrations/005_stripe_payment_foundation.sql` which creates a new `public.payment_status` enum with `pending`, `succeeded`, `failed`, and `refunded`.
- Creates `public.payment_events` with UUID primary key, `user_id` FK to `public.users(id)`, `provider`, `provider_reference`, `amount_cents`, `currency`, `status` (enum), `raw_payload` JSONB, `created_at`, and `UNIQUE(provider, provider_reference)` for idempotency.
- Enables Row-Level Security on `payment_events` and creates a `payment_events_select_own` policy limiting `SELECT` to rows where `user_id = auth.uid()`.
- Revokes all public privileges on the table and grants `SELECT` to `authenticated` and `INSERT` only to `service_role`, preventing clients from inserting or mutating events.

### Testing

- Verified the migration file contents with `sed -n` and `nl` which displayed the created enum, table, constraints, RLS, and grants (success).
- Verified repository state with `git status --short` and committed the migration with `git commit` (success).
- Created the follow-up PR via the repository `make_pr` helper (success).
- Attempted to fetch external Postgres docs with `curl` but the request failed due to a network/proxy `403` which did not affect local migration verification (network check failed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a2a8c078188331a180deca8c5256fc)