### PR TITLE
feat(db): add migration 006 – atomic Stripe webhook processor

### DIFF
--- a/packages/db/migrations/006_stripe_webhook_processor.sql
+++ b/packages/db/migrations/006_stripe_webhook_processor.sql
@@ -1,0 +1,74 @@
+CREATE OR REPLACE FUNCTION public.process_stripe_payment(
+  p_user_id uuid,
+  p_provider_reference text,
+  p_amount_cents integer,
+  p_currency text,
+  p_status public.payment_status,
+  p_raw_payload jsonb
+)
+RETURNS uuid
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_payment_event_id uuid;
+BEGIN
+  INSERT INTO public.payment_events (
+    user_id,
+    provider,
+    provider_reference,
+    amount_cents,
+    currency,
+    status,
+    raw_payload
+  )
+  VALUES (
+    p_user_id,
+    'stripe',
+    p_provider_reference,
+    p_amount_cents,
+    p_currency,
+    p_status,
+    p_raw_payload
+  )
+  ON CONFLICT (provider, provider_reference) DO NOTHING
+  RETURNING id INTO v_payment_event_id;
+
+  IF v_payment_event_id IS NULL THEN
+    RETURN NULL;
+  END IF;
+
+  IF p_status = 'succeeded' THEN
+    PERFORM public.add_credits(p_user_id, p_amount_cents);
+  END IF;
+
+  RETURN v_payment_event_id;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.process_stripe_payment(
+  uuid,
+  text,
+  integer,
+  text,
+  public.payment_status,
+  jsonb
+) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.process_stripe_payment(
+  uuid,
+  text,
+  integer,
+  text,
+  public.payment_status,
+  jsonb
+) FROM authenticated;
+
+GRANT EXECUTE ON FUNCTION public.process_stripe_payment(
+  uuid,
+  text,
+  integer,
+  text,
+  public.payment_status,
+  jsonb
+) TO service_role;


### PR DESCRIPTION
### Motivation

- Provide an atomic, idempotent Stripe webhook processor that records events and prevents duplicate crediting. 
- Ensure credits are applied exactly once and only for successful payments while running inside a secure, definer-level function. 
- Restrict execution to the `service_role` so clients and `authenticated` roles cannot invoke the processor.

### Description

- Added a new migration file `packages/db/migrations/006_stripe_webhook_processor.sql` that defines `public.process_stripe_payment(...)` as a `LANGUAGE plpgsql`, `SECURITY DEFINER` function with `SET search_path = public`.
- The function inserts into `public.payment_events` with `provider = 'stripe'` and uses `ON CONFLICT (provider, provider_reference) DO NOTHING` to implement idempotency and returns the inserted `id` or `NULL` on duplicate.
- Credits are applied only when the insert succeeds and `p_status = 'succeeded'` by calling `public.add_credits(p_user_id, p_amount_cents)`, using the conversion rule of `1 cent = 1 credit`.
- Hardened permissions by revoking public/authenticated access to the function and granting `EXECUTE` only to `service_role`.

### Testing

- Created and inspected the migration file contents using `sed -n '1,220p' packages/db/migrations/006_stripe_webhook_processor.sql` and `nl -ba packages/db/migrations/006_stripe_webhook_processor.sql` to verify the function body and permission statements. 
- Verified the migration file is present in the repository working tree at `packages/db/migrations/006_stripe_webhook_processor.sql` after adding the file. 
- Attempted an external lookup to validate `INSERT ... ON CONFLICT ... RETURNING` patterns, but the web lookup was blocked in this environment (network request failed). 
- No database migration runtime or integration tests were executed in this environment; runtime validation should be performed when applying the migration to a staging database.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a2c3da35c0833194c96e837b2fb336)