### PR TITLE
Implement Atomic Credit Deduction & Job Creation RPC (Secure & Server-Enforced)

### DIFF
--- a/apps/web/app/api/jobs/create/route.ts
+++ b/apps/web/app/api/jobs/create/route.ts
@@ -1,0 +1,119 @@
+import { createClient } from '@supabase/supabase-js';
+
+type CreateJobRequest = {
+  payload?: unknown;
+};
+
+type CreateJobRpcResponse = {
+  data: string | null;
+  error: { message: string } | null;
+};
+
+const VIDEO_JOB_COST = 10;
+
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+const supabaseServiceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+function missingEnvResponse(name: string) {
+  return Response.json(
+    { error: `Missing required environment variable: ${name}` },
+    { status: 500 }
+  );
+}
+
+function getBearerToken(request: Request): string | null {
+  const authorizationHeader = request.headers.get('authorization');
+  if (!authorizationHeader?.startsWith('Bearer ')) {
+    return null;
+  }
+
+  return authorizationHeader.slice('Bearer '.length).trim() || null;
+}
+
+function isJsonObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+export async function POST(request: Request) {
+  if (!supabaseUrl) {
+    return missingEnvResponse('NEXT_PUBLIC_SUPABASE_URL');
+  }
+
+  if (!supabaseAnonKey) {
+    return missingEnvResponse('NEXT_PUBLIC_SUPABASE_ANON_KEY');
+  }
+
+  if (!supabaseServiceRoleKey) {
+    return missingEnvResponse('SUPABASE_SERVICE_ROLE_KEY');
+  }
+
+  const accessToken = getBearerToken(request);
+  if (!accessToken) {
+    return Response.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const authClient = createClient(supabaseUrl, supabaseAnonKey, {
+    auth: {
+      persistSession: false,
+      autoRefreshToken: false
+    },
+    global: {
+      headers: {
+        Authorization: `Bearer ${accessToken}`
+      }
+    }
+  });
+
+  const {
+    data: { user },
+    error: userError
+  } = await authClient.auth.getUser();
+
+  if (userError || !user) {
+    return Response.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  let requestBody: CreateJobRequest;
+
+  try {
+    requestBody = (await request.json()) as CreateJobRequest;
+  } catch {
+    return Response.json({ error: 'Invalid JSON body' }, { status: 400 });
+  }
+
+  if (!isJsonObject(requestBody.payload)) {
+    return Response.json({ error: 'Invalid payload' }, { status: 400 });
+  }
+
+  const serviceClient = createClient(supabaseUrl, supabaseServiceRoleKey, {
+    auth: {
+      persistSession: false,
+      autoRefreshToken: false
+    }
+  });
+
+  const rpcResponse = (await serviceClient.rpc('create_video_job', {
+    p_user_id: user.id,
+    p_cost: VIDEO_JOB_COST,
+    p_payload: requestBody.payload
+  })) as CreateJobRpcResponse;
+
+  if (rpcResponse.error || !rpcResponse.data) {
+    console.error('create_video_job RPC failed', {
+      userId: user.id,
+      message: rpcResponse.error?.message
+    });
+
+    const isInsufficientCredits =
+      rpcResponse.error?.message?.toLowerCase().includes('insufficient credits') ?? false;
+
+    if (isInsufficientCredits) {
+      return Response.json({ error: 'Insufficient credits' }, { status: 402 });
+    }
+
+    return Response.json({ error: 'Unable to create job' }, { status: 400 });
+  }
+
+  return Response.json({ job_id: rpcResponse.data }, { status: 200 });
+}

--- a/packages/db/migrations/007_create_video_job_rpc.sql
+++ b/packages/db/migrations/007_create_video_job_rpc.sql
@@ -1,0 +1,60 @@
+CREATE OR REPLACE FUNCTION public.create_video_job(
+  p_user_id uuid,
+  p_cost integer,
+  p_payload jsonb
+)
+RETURNS uuid
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_job_id uuid;
+  v_video_id uuid;
+BEGIN
+  IF p_user_id IS NULL THEN
+    RAISE EXCEPTION 'User id is required';
+  END IF;
+
+  IF p_cost IS NULL OR p_cost <= 0 THEN
+    RAISE EXCEPTION 'Cost must be greater than zero';
+  END IF;
+
+  IF p_payload IS NULL OR jsonb_typeof(p_payload) <> 'object' THEN
+    RAISE EXCEPTION 'Payload must be a JSON object';
+  END IF;
+
+  BEGIN
+    v_video_id := (p_payload ->> 'video_id')::uuid;
+  EXCEPTION
+    WHEN invalid_text_representation THEN
+      RAISE EXCEPTION 'Payload video_id must be a valid UUID';
+  END;
+
+  IF v_video_id IS NULL THEN
+    RAISE EXCEPTION 'Payload video_id is required';
+  END IF;
+
+  PERFORM set_config('request.jwt.claim.sub', p_user_id::text, true);
+
+  PERFORM public.deduct_credits(p_cost);
+
+  INSERT INTO public.jobs (video_id)
+  SELECT v.id
+  FROM public.videos AS v
+  WHERE v.id = v_video_id
+    AND v.user_id = p_user_id
+  RETURNING id INTO v_job_id;
+
+  IF v_job_id IS NULL THEN
+    RAISE EXCEPTION 'Video not found for user';
+  END IF;
+
+  RETURN v_job_id;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.create_video_job(uuid, integer, jsonb) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.create_video_job(uuid, integer, jsonb) FROM authenticated;
+
+GRANT EXECUTE ON FUNCTION public.create_video_job(uuid, integer, jsonb) TO service_role;


### PR DESCRIPTION
### Motivation
- Ensure job creation deducts credits atomically at the database level to prevent race conditions and client-side bypass. 
- Centralize credit enforcement in a DB-side RPC so the operation is secure, atomic, and compatible with existing RLS and `deduct_credits`. 
- Expose a server-only API endpoint that cannot be used to manipulate costs or credits from the frontend.

### Description
- Added migration `packages/db/migrations/007_create_video_job_rpc.sql` which creates `public.create_video_job(p_user_id uuid, p_cost integer, p_payload jsonb)` as a `SECURITY DEFINER` function that validates inputs, parses and validates `payload.video_id`, calls `public.deduct_credits(p_cost)`, inserts into `public.jobs`, and returns the created `job_id`.
- Locked down RPC permissions by revoking `EXECUTE` from `PUBLIC` and `authenticated` and granting `EXECUTE` only to `service_role`.
- Added API route `apps/web/app/api/jobs/create/route.ts` which requires an authenticated session, enforces a server-side `VIDEO_JOB_COST` constant, uses the `SUPABASE_SERVICE_ROLE_KEY` to call the `create_video_job` RPC, validates request payload shape, and maps DB RPC errors to safe client responses while logging internal failure details.
- Implemented input validation and safe error handling so insufficient credits return a controlled `402` response and other failures return a generic `400` with server-side logging.

### Testing
- Ran `npx tsc -p apps/web/tsconfig.json --noEmit` which initially failed due to missing dependencies, then ran `npm install` which completed successfully. 
- Re-ran `npx tsc -p apps/web/tsconfig.json --noEmit` after installing dependencies and TypeScript compilation succeeded with no errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a3f7526d108331a4f9bb49dc261736)