### PR TITLE
Implement Job Queue Producer & Worker Consumer Integration (Async Video Processing)

### DIFF
--- a/apps/web/app/api/jobs/create/route.ts
+++ b/apps/web/app/api/jobs/create/route.ts
@@ -9,6 +9,20 @@ type CreateJobRpcResponse = {
   error: { message: string } | null;
 };
 
+type JobQueueMessage = {
+  job_id: string;
+  user_id: string;
+  payload: Record<string, unknown>;
+};
+
+type QueueBinding = {
+  send: (message: JobQueueMessage) => Promise<void>;
+};
+
+type RuntimeWithQueue = typeof globalThis & {
+  VIDEO_JOB_QUEUE?: QueueBinding;
+};
+
 const VIDEO_JOB_COST = 10;
 
 const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
@@ -33,6 +47,31 @@ function getBearerToken(request: Request): string | null {
 
 function isJsonObject(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function getQueueBinding(): QueueBinding | null {
+  const runtime = globalThis as RuntimeWithQueue;
+
+  return runtime.VIDEO_JOB_QUEUE ?? null;
+}
+
+function enqueueJob(message: JobQueueMessage): void {
+  const queue = getQueueBinding();
+
+  if (!queue) {
+    console.error('Queue binding VIDEO_JOB_QUEUE is not available', {
+      jobId: message.job_id
+    });
+    return;
+  }
+
+  void queue.send(message).catch((error: unknown) => {
+    console.error('Failed to enqueue video job', {
+      jobId: message.job_id,
+      userId: message.user_id,
+      message: error instanceof Error ? error.message : 'Unknown error'
+    });
+  });
 }
 
 export async function POST(request: Request) {
@@ -115,5 +154,13 @@ export async function POST(request: Request) {
     return Response.json({ error: 'Unable to create job' }, { status: 400 });
   }
 
-  return Response.json({ job_id: rpcResponse.data }, { status: 200 });
+  const jobId = rpcResponse.data;
+
+  enqueueJob({
+    job_id: jobId,
+    user_id: user.id,
+    payload: requestBody.payload
+  });
+
+  return Response.json({ job_id: jobId }, { status: 200 });
 }

--- a/apps/worker-api/wrangler.toml
+++ b/apps/worker-api/wrangler.toml
@@ -1,3 +1,7 @@
 name = "pat87creator-worker-api"
 main = "src/index.ts"
 compatibility_date = "2024-10-01"
+
+[[queues.producers]]
+binding = "VIDEO_JOB_QUEUE"
+queue = "video-job-queue"

--- a/apps/worker-consumer/src/index.ts
+++ b/apps/worker-consumer/src/index.ts
@@ -1,9 +1,128 @@
-export interface QueueBatch<T = unknown> {
-  messages: T[];
+import { createClient } from '@supabase/supabase-js';
+
+type JobStatus = 'queued' | 'processing' | 'completed' | 'failed';
+
+type JobQueueMessage = {
+  job_id: string;
+  user_id: string;
+  payload: Record<string, unknown>;
+};
+
+type JobRow = {
+  id: string;
+  status: JobStatus;
+};
+
+type Env = {
+  NEXT_PUBLIC_SUPABASE_URL: string;
+  SUPABASE_SERVICE_ROLE_KEY: string;
+};
+
+function createServiceClient(env: Env) {
+  return createClient(env.NEXT_PUBLIC_SUPABASE_URL, env.SUPABASE_SERVICE_ROLE_KEY, {
+    auth: {
+      persistSession: false,
+      autoRefreshToken: false
+    }
+  });
+}
+
+async function updateJobStatus(
+  env: Env,
+  jobId: string,
+  status: JobStatus,
+  errorMessage?: string
+): Promise<void> {
+  const client = createServiceClient(env);
+  const payload: { status: JobStatus; error_message?: string | null } = { status };
+
+  if (status === 'failed') {
+    payload.error_message = errorMessage ?? 'Unknown worker failure';
+  } else {
+    payload.error_message = null;
+  }
+
+  const { error } = await client.from('jobs').update(payload).eq('id', jobId);
+
+  if (error) {
+    throw new Error(`Unable to update job status: ${error.message}`);
+  }
+}
+
+async function simulateProcessing(): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, 100));
+}
+
+async function processMessage(message: Message<JobQueueMessage>, env: Env): Promise<void> {
+  const body = message.body;
+
+  if (!body?.job_id) {
+    throw new Error('Queue message missing job_id');
+  }
+
+  const client = createServiceClient(env);
+  const { data: job, error: fetchError } = await client
+    .from('jobs')
+    .select('id, status')
+    .eq('id', body.job_id)
+    .maybeSingle<JobRow>();
+
+  if (fetchError) {
+    throw new Error(`Unable to fetch job: ${fetchError.message}`);
+  }
+
+  if (!job) {
+    console.error('Job not found for queued message', { jobId: body.job_id });
+    return;
+  }
+
+  if (job.status === 'completed') {
+    console.log('Skipping already completed job', { jobId: body.job_id });
+    return;
+  }
+
+  if (job.status !== 'queued') {
+    console.log('Skipping job because status is not queued', {
+      jobId: body.job_id,
+      status: job.status
+    });
+    return;
+  }
+
+  try {
+    await updateJobStatus(env, body.job_id, 'processing');
+    await simulateProcessing();
+    await updateJobStatus(env, body.job_id, 'completed');
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : 'Unknown processing failure';
+
+    console.error('Video job processing failed', {
+      jobId: body.job_id,
+      userId: body.user_id,
+      message: errorMessage
+    });
+
+    await updateJobStatus(env, body.job_id, 'failed', errorMessage);
+  }
 }
 
 export default {
-  async queue(_batch: QueueBatch): Promise<void> {
-    // queue consumer stub
+  async queue(batch: MessageBatch<JobQueueMessage>, env: Env): Promise<void> {
+    if (!env.NEXT_PUBLIC_SUPABASE_URL || !env.SUPABASE_SERVICE_ROLE_KEY) {
+      console.error('Missing required worker environment variables');
+      return;
+    }
+
+    for (const message of batch.messages) {
+      try {
+        await processMessage(message, env);
+        message.ack();
+      } catch (error) {
+        console.error('Unhandled queue message error', {
+          message: error instanceof Error ? error.message : 'Unknown error'
+        });
+        message.retry();
+      }
+    }
   }
 };

--- a/apps/worker-consumer/wrangler.toml
+++ b/apps/worker-consumer/wrangler.toml
@@ -1,3 +1,12 @@
 name = "pat87creator-worker-consumer"
 main = "src/index.ts"
 compatibility_date = "2024-10-01"
+
+[[queues.consumers]]
+queue = "video-job-queue"
+max_batch_size = 10
+max_batch_timeout = 5
+
+[vars]
+# Populate per-environment via wrangler secret/vars.
+NEXT_PUBLIC_SUPABASE_URL = ""

--- a/packages/db/migrations/008_job_status_enum.sql
+++ b/packages/db/migrations/008_job_status_enum.sql
@@ -1,0 +1,43 @@
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_type
+    WHERE typname = 'job_status'
+      AND typnamespace = 'public'::regnamespace
+  ) THEN
+    CREATE TYPE public.job_status AS ENUM ('queued', 'processing', 'completed', 'failed');
+  END IF;
+END
+$$;
+
+ALTER TABLE public.jobs
+  ALTER COLUMN status DROP DEFAULT,
+  ALTER COLUMN status TYPE public.job_status USING (
+    CASE
+      WHEN status IN ('queued', 'processing', 'completed', 'failed') THEN status::public.job_status
+      WHEN status = 'pending' THEN 'queued'::public.job_status
+      ELSE 'queued'::public.job_status
+    END
+  ),
+  ALTER COLUMN status SET DEFAULT 'queued'::public.job_status;
+
+ALTER TABLE public.jobs
+  ADD COLUMN IF NOT EXISTS updated_at TIMESTAMPTZ NOT NULL DEFAULT now();
+
+CREATE OR REPLACE FUNCTION public.set_updated_at_timestamp()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  NEW.updated_at = now();
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_jobs_set_updated_at ON public.jobs;
+
+CREATE TRIGGER trg_jobs_set_updated_at
+BEFORE UPDATE ON public.jobs
+FOR EACH ROW
+EXECUTE FUNCTION public.set_updated_at_timestamp();


### PR DESCRIPTION
### Motivation
- Introduce asynchronous processing for created video jobs so the API remains responsive while background workers perform the heavy work.
- Ensure reliable, idempotent job lifecycle transitions (queued → processing → completed/failed) and safe server-side error handling.
- Use Cloudflare Queues + Cloudflare Workers with Supabase service role to process jobs without exposing secrets or allowing client-controlled status/cost.

### Description
- API producer: updated `apps/web/app/api/jobs/create/route.ts` to enqueue a typed queue message (`job_id`, `user_id`, `payload`) via the `VIDEO_JOB_QUEUE` binding and to return `job_id` immediately without blocking; queue send is non-blocking and failures are logged server-side only.
- Worker consumer: implemented `apps/worker-consumer/src/index.ts` to consume queue messages, fetch the job with a Supabase service client (`SUPABASE_SERVICE_ROLE_KEY`), enforce `status === 'queued'`, transition `queued -> processing -> completed`, set `failed` on errors, and skip already `completed` jobs (idempotency); errors are logged and retried via message controls.
- Database migration: added `packages/db/migrations/008_job_status_enum.sql` to create `public.job_status` enum (queued|processing|completed|failed), migrate existing `jobs.status` (mapping `pending` → `queued`), set default to `queued`, and add/maintain `updated_at` via trigger.
- Cloudflare configuration: added producer binding in `apps/worker-api/wrangler.toml` (`VIDEO_JOB_QUEUE`) and consumer queue config in `apps/worker-consumer/wrangler.toml`; queue access is via bindings (no hardcoded queue names/secrets in runtime code).

### Testing
- Ran `npm run build:worker-consumer` which completed successfully (wrangler dry-run showed consumer config present).
- Ran `npm run build:worker-api` which completed successfully (wrangler dry-run showed producer binding present).
- `npm run build:web` failed in this environment during Next.js prerender due to missing Supabase env vars (`supabaseUrl is required`); this is an environment configuration issue and not a code/runtime regression.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4306fe3008331858b56f62ac08c78)