### PR TITLE
Implement Job Retry, Timeout Recovery & Dead Letter Handling (Production Resilience Layer)

### DIFF
--- a/apps/worker-consumer/src/index.ts
+++ b/apps/worker-consumer/src/index.ts
@@ -11,12 +11,17 @@ type JobQueueMessage = {
 type JobRow = {
   id: string;
   status: JobStatus;
+  attempt_count: number;
+  locked_at: string | null;
 };
 
 type Env = {
   NEXT_PUBLIC_SUPABASE_URL: string;
   SUPABASE_SERVICE_ROLE_KEY: string;
 };
+
+const MAX_RETRIES = 3;
+const PROCESSING_TIMEOUT_MS = 5 * 60 * 1000;
 
 function createServiceClient(env: Env) {
   return createClient(env.NEXT_PUBLIC_SUPABASE_URL, env.SUPABASE_SERVICE_ROLE_KEY, {
@@ -27,22 +32,72 @@ function createServiceClient(env: Env) {
   });
 }
 
-async function updateJobStatus(
+function isLockExpired(lockedAt: string | null): boolean {
+  if (!lockedAt) {
+    return true;
+  }
+
+  return Date.now() - new Date(lockedAt).getTime() >= PROCESSING_TIMEOUT_MS;
+}
+
+async function startProcessing(env: Env, job: JobRow): Promise<number> {
+  const client = createServiceClient(env);
+  const nextAttemptCount = job.attempt_count + 1;
+  const nowIso = new Date().toISOString();
+
+  const { data, error } = await client
+    .from('jobs')
+    .update({
+      status: 'processing',
+      attempt_count: nextAttemptCount,
+      last_attempt_at: nowIso,
+      locked_at: nowIso,
+      error_message: null
+    })
+    .eq('id', job.id)
+    .eq('status', job.status)
+    .eq('attempt_count', job.attempt_count)
+    .select('attempt_count')
+    .maybeSingle<{ attempt_count: number }>();
+
+  if (error) {
+    throw new Error(`Unable to set processing status: ${error.message}`);
+  }
+
+  if (!data) {
+    throw new Error('Unable to claim job for processing due to concurrent update');
+  }
+
+  return data.attempt_count;
+}
+
+async function updateFinalStatus(
   env: Env,
   jobId: string,
-  status: JobStatus,
+  status: 'queued' | 'completed' | 'failed',
+  attemptCount: number,
   errorMessage?: string
 ): Promise<void> {
   const client = createServiceClient(env);
-  const payload: { status: JobStatus; error_message?: string | null } = { status };
+  const payload: {
+    status: 'queued' | 'completed' | 'failed';
+    locked_at: null;
+    error_message?: string | null;
+  } = {
+    status,
+    locked_at: null
+  };
 
   if (status === 'failed') {
     payload.error_message = errorMessage ?? 'Unknown worker failure';
-  } else {
-    payload.error_message = null;
   }
 
-  const { error } = await client.from('jobs').update(payload).eq('id', jobId);
+  const { error } = await client
+    .from('jobs')
+    .update(payload)
+    .eq('id', jobId)
+    .eq('attempt_count', attemptCount)
+    .eq('status', 'processing');
 
   if (error) {
     throw new Error(`Unable to update job status: ${error.message}`);
@@ -63,7 +118,7 @@ async function processMessage(message: Message<JobQueueMessage>, env: Env): Prom
   const client = createServiceClient(env);
   const { data: job, error: fetchError } = await client
     .from('jobs')
-    .select('id, status')
+    .select('id, status, attempt_count, locked_at')
     .eq('id', body.job_id)
     .maybeSingle<JobRow>();
 
@@ -72,37 +127,79 @@ async function processMessage(message: Message<JobQueueMessage>, env: Env): Prom
   }
 
   if (!job) {
-    console.error('Job not found for queued message', { jobId: body.job_id });
+    console.error('Job not found for queued message', { job_id: body.job_id });
     return;
   }
 
   if (job.status === 'completed') {
-    console.log('Skipping already completed job', { jobId: body.job_id });
-    return;
-  }
-
-  if (job.status !== 'queued') {
-    console.log('Skipping job because status is not queued', {
-      jobId: body.job_id,
-      status: job.status
+    console.log('Skipping already completed job', {
+      job_id: body.job_id,
+      attempt_count: job.attempt_count,
+      transition: 'completed -> completed'
     });
     return;
   }
+
+  if (job.status === 'failed' && job.attempt_count >= MAX_RETRIES) {
+    console.log('Skipping dead-lettered job', {
+      job_id: body.job_id,
+      attempt_count: job.attempt_count,
+      transition: 'failed -> failed'
+    });
+    return;
+  }
+
+  if (job.status === 'processing' && !isLockExpired(job.locked_at)) {
+    console.log('Skipping currently locked processing job', {
+      job_id: body.job_id,
+      attempt_count: job.attempt_count,
+      transition: 'processing -> processing'
+    });
+    return;
+  }
+
+  if (job.status !== 'queued' && job.status !== 'processing' && job.status !== 'failed') {
+    return;
+  }
+
+  let startedAttempt = job.attempt_count;
 
   try {
-    await updateJobStatus(env, body.job_id, 'processing');
-    await simulateProcessing();
-    await updateJobStatus(env, body.job_id, 'completed');
-  } catch (error) {
-    const errorMessage = error instanceof Error ? error.message : 'Unknown processing failure';
+    startedAttempt = await startProcessing(env, job);
 
-    console.error('Video job processing failed', {
-      jobId: body.job_id,
-      userId: body.user_id,
-      message: errorMessage
+    console.log('Transitioning job to processing', {
+      job_id: body.job_id,
+      attempt_count: startedAttempt,
+      transition: `${job.status} -> processing`
     });
 
-    await updateJobStatus(env, body.job_id, 'failed', errorMessage);
+    await simulateProcessing();
+
+    await updateFinalStatus(env, body.job_id, 'completed', startedAttempt);
+
+    console.log('Transitioning job to completed', {
+      job_id: body.job_id,
+      attempt_count: startedAttempt,
+      transition: 'processing -> completed'
+    });
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : 'Unknown processing failure';
+    const nextStatus: 'queued' | 'failed' = startedAttempt < MAX_RETRIES ? 'queued' : 'failed';
+
+    console.error('Video job processing failed', {
+      job_id: body.job_id,
+      attempt_count: startedAttempt,
+      transition: `processing -> ${nextStatus}`,
+      error: errorMessage
+    });
+
+    await updateFinalStatus(
+      env,
+      body.job_id,
+      nextStatus,
+      startedAttempt,
+      nextStatus === 'failed' ? errorMessage : undefined
+    );
   }
 }
 

--- a/packages/db/migrations/009_job_retry_and_timeout.sql
+++ b/packages/db/migrations/009_job_retry_and_timeout.sql
@@ -1,0 +1,8 @@
+ALTER TABLE public.jobs
+  ADD COLUMN IF NOT EXISTS attempt_count INTEGER NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS last_attempt_at TIMESTAMPTZ,
+  ADD COLUMN IF NOT EXISTS locked_at TIMESTAMPTZ,
+  ADD COLUMN IF NOT EXISTS error_message TEXT;
+
+CREATE INDEX IF NOT EXISTS jobs_status_locked_at_idx
+  ON public.jobs (status, locked_at);


### PR DESCRIPTION
### Motivation
- Jobs could become stuck in `processing` if a worker crashes, and there was no retry or dead-letter handling.  
- The system lacked attempt tracking and lock metadata needed to safely retry or recover timed-out work.  
- This change adds a minimal resilience layer to ensure idempotent retries, bounded attempts, and observability for job lifecycle issues.

### Description
- Added migration `packages/db/migrations/009_job_retry_and_timeout.sql` to extend `jobs` with `attempt_count`, `last_attempt_at`, `locked_at`, and ensure `error_message` exists, plus an index on `(status, locked_at)`.  
- Introduced `MAX_RETRIES = 3` and `PROCESSING_TIMEOUT_MS = 5 * 60 * 1000` constants and a lock-expiration helper `isLockExpired` in `apps/worker-consumer/src/index.ts`.  
- Implemented safe claim logic (`startProcessing`) that atomically increments `attempt_count`, sets `locked_at`/`last_attempt_at`, and uses optimistic equality checks to avoid race conditions.  
- Implemented `updateFinalStatus` to clear locks and transition to `queued`/`completed`/`failed` with persisted `error_message`, idempotent guards for completed/dead-lettered jobs, and structured logging including `job_id`, `attempt_count`, transition, and error details; worker continues to use `SUPABASE_SERVICE_ROLE_KEY` and does not change Stripe or credit logic.

### Testing
- Built the worker with `npm run build:worker-consumer`, which ran `wrangler deploy --dry-run` and completed successfully with no build errors.  
- No automated test failures were reported and TypeScript build output did not surface type errors during the worker build.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a51129888483319bbea3f7cd73e4b4)