### PR TITLE
Phase 18: Transactional job cost tracking, economics finalization & admin margin metrics

### DIFF
--- a/apps/worker-api/src/index.ts
+++ b/apps/worker-api/src/index.ts
@@ -30,6 +30,10 @@ type MetricsRow = {
   queued: number;
   avg_execution_ms: number;
   retry_rate: number;
+  total_cost_usd: number;
+  total_revenue_usd: number;
+  total_margin_usd: number;
+  avg_margin_per_job: number;
 };
 
 const DEFAULT_PAGE = 1;
@@ -187,7 +191,11 @@ async function handleAdminMetrics(request: Request, env: Env): Promise<Response>
     processing: data?.processing ?? 0,
     queued: data?.queued ?? 0,
     avg_execution_ms: data?.avg_execution_ms ?? 0,
-    retry_rate: data?.retry_rate ?? 0
+    retry_rate: data?.retry_rate ?? 0,
+    total_cost_usd: data?.total_cost_usd ?? 0,
+    total_revenue_usd: data?.total_revenue_usd ?? 0,
+    total_margin_usd: data?.total_margin_usd ?? 0,
+    avg_margin_per_job: data?.avg_margin_per_job ?? 0
   });
 }
 

--- a/apps/worker-consumer/src/index.ts
+++ b/apps/worker-consumer/src/index.ts
@@ -23,6 +23,12 @@ type JobRow = {
   processing_started_at: string | null;
 };
 
+type FinalizeEconomicsRow = {
+  total_cost_usd: number;
+  revenue_usd: number;
+  margin_usd: number;
+};
+
 type StartedJob = {
   attemptCount: number;
   processingToken: string;
@@ -38,6 +44,8 @@ type Env = {
 const MAX_RETRIES = 3;
 const PROCESSING_TIMEOUT_MS = 5 * 60 * 1000;
 const DEFAULT_ARTIFACT_BUCKET = 'videos';
+const COMPUTE_COST_PER_SECOND_USD = 0.0004;
+const CREDIT_PRICE_USD = 0.01;
 
 function createServiceClient(env: Env) {
   return createClient(env.NEXT_PUBLIC_SUPABASE_URL, env.SUPABASE_SERVICE_ROLE_KEY, {
@@ -158,7 +166,7 @@ async function updateFinalStatus(
   processingToken: string,
   processingStartedAt: string,
   errorMessage?: string
-): Promise<void> {
+): Promise<number> {
   const client = createServiceClient(env);
   const payload: {
     status: 'queued' | 'completed' | 'failed';
@@ -195,6 +203,34 @@ async function updateFinalStatus(
   if (error) {
     throw new Error(`Unable to update job status: ${error.message}`);
   }
+
+  return durationMs;
+}
+
+async function finalizeJobEconomics(env: Env, jobId: string, executionDurationMs: number): Promise<void> {
+  const client = createServiceClient(env);
+  const computeCostUsd = (executionDurationMs / 1000) * COMPUTE_COST_PER_SECOND_USD;
+
+  const { data, error } = await client.rpc('finalize_job_economics', {
+    p_job_id: jobId,
+    p_compute_cost_usd: computeCostUsd,
+    p_storage_cost_usd: 0,
+    p_external_api_cost_usd: 0,
+    p_credit_price_usd: CREDIT_PRICE_USD
+  });
+
+  if (error) {
+    throw new Error(`Unable to finalize job economics: ${error.message}`);
+  }
+
+  const result = (Array.isArray(data) ? data[0] : data) as FinalizeEconomicsRow | null;
+  console.log('Job economics finalized', {
+    job_id: jobId,
+    execution_duration_ms: executionDurationMs,
+    total_cost_usd: result?.total_cost_usd ?? null,
+    revenue_usd: result?.revenue_usd ?? null,
+    margin_usd: result?.margin_usd ?? null
+  });
 }
 
 async function simulateProcessing(): Promise<void> {
@@ -293,7 +329,7 @@ async function processMessage(message: Message<JobQueueMessage>, env: Env): Prom
         skip_reason: 'result_payload_exists'
       });
 
-      await updateFinalStatus(
+      const durationMs = await updateFinalStatus(
         env,
         body.job_id,
         'completed',
@@ -301,6 +337,7 @@ async function processMessage(message: Message<JobQueueMessage>, env: Env): Prom
         started.processingToken,
         started.processingStartedAt
       );
+      await finalizeJobEconomics(env, body.job_id, durationMs);
       return;
     }
 
@@ -323,7 +360,7 @@ async function processMessage(message: Message<JobQueueMessage>, env: Env): Prom
       });
 
       await persistResultPayload(env, body.job_id, started.attemptCount, started.processingToken, payload);
-      await updateFinalStatus(
+      const durationMs = await updateFinalStatus(
         env,
         body.job_id,
         'completed',
@@ -331,6 +368,7 @@ async function processMessage(message: Message<JobQueueMessage>, env: Env): Prom
         started.processingToken,
         started.processingStartedAt
       );
+      await finalizeJobEconomics(env, body.job_id, durationMs);
       return;
     }
 
@@ -342,7 +380,7 @@ async function processMessage(message: Message<JobQueueMessage>, env: Env): Prom
     };
 
     await persistResultPayload(env, body.job_id, started.attemptCount, started.processingToken, payload);
-    await updateFinalStatus(
+    const durationMs = await updateFinalStatus(
       env,
       body.job_id,
       'completed',
@@ -350,6 +388,7 @@ async function processMessage(message: Message<JobQueueMessage>, env: Env): Prom
       started.processingToken,
       started.processingStartedAt
     );
+    await finalizeJobEconomics(env, body.job_id, durationMs);
 
     console.log('Transitioning job to completed', {
       job_id: body.job_id,

--- a/packages/db/migrations/012_job_costs_and_unit_economics.sql
+++ b/packages/db/migrations/012_job_costs_and_unit_economics.sql
@@ -1,0 +1,189 @@
+ALTER TABLE public.jobs
+  ADD COLUMN IF NOT EXISTS revenue_usd NUMERIC(10,6),
+  ADD COLUMN IF NOT EXISTS billed_credits INTEGER NOT NULL DEFAULT 0;
+
+CREATE TABLE IF NOT EXISTS public.job_costs (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  job_id UUID NOT NULL REFERENCES public.jobs(id) ON DELETE CASCADE,
+  cost_type TEXT NOT NULL CHECK (cost_type IN ('compute', 'storage', 'external_api')),
+  amount_usd NUMERIC(10,6) NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  UNIQUE (job_id, cost_type)
+);
+
+CREATE INDEX IF NOT EXISTS job_costs_job_id_idx ON public.job_costs(job_id);
+
+
+
+CREATE OR REPLACE FUNCTION public.create_video_job(
+  p_user_id uuid,
+  p_cost integer,
+  p_payload jsonb
+)
+RETURNS uuid
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_job_id uuid;
+  v_video_id uuid;
+BEGIN
+  IF p_user_id IS NULL THEN
+    RAISE EXCEPTION 'User id is required';
+  END IF;
+
+  IF p_cost IS NULL OR p_cost <= 0 THEN
+    RAISE EXCEPTION 'Cost must be greater than zero';
+  END IF;
+
+  IF p_payload IS NULL OR jsonb_typeof(p_payload) <> 'object' THEN
+    RAISE EXCEPTION 'Payload must be a JSON object';
+  END IF;
+
+  BEGIN
+    v_video_id := (p_payload ->> 'video_id')::uuid;
+  EXCEPTION
+    WHEN invalid_text_representation THEN
+      RAISE EXCEPTION 'Payload video_id must be a valid UUID';
+  END;
+
+  IF v_video_id IS NULL THEN
+    RAISE EXCEPTION 'Payload video_id is required';
+  END IF;
+
+  PERFORM set_config('request.jwt.claim.sub', p_user_id::text, true);
+
+  PERFORM public.deduct_credits(p_cost);
+
+  INSERT INTO public.jobs (video_id, billed_credits)
+  SELECT v.id, p_cost
+  FROM public.videos AS v
+  WHERE v.id = v_video_id
+    AND v.user_id = p_user_id
+  RETURNING id INTO v_job_id;
+
+  IF v_job_id IS NULL THEN
+    RAISE EXCEPTION 'Video not found for user';
+  END IF;
+
+  RETURN v_job_id;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.finalize_job_economics(
+  p_job_id uuid,
+  p_compute_cost_usd numeric,
+  p_storage_cost_usd numeric DEFAULT 0,
+  p_external_api_cost_usd numeric DEFAULT 0,
+  p_credit_price_usd numeric DEFAULT 0.01
+)
+RETURNS TABLE(total_cost_usd numeric, revenue_usd numeric, margin_usd numeric)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_billed_credits integer;
+  v_revenue_usd numeric(10,6);
+BEGIN
+  IF p_job_id IS NULL THEN
+    RAISE EXCEPTION 'Job id is required';
+  END IF;
+
+  IF p_credit_price_usd IS NULL OR p_credit_price_usd <= 0 THEN
+    RAISE EXCEPTION 'Credit price must be positive';
+  END IF;
+
+  IF COALESCE(p_compute_cost_usd, 0) < 0
+     OR COALESCE(p_storage_cost_usd, 0) < 0
+     OR COALESCE(p_external_api_cost_usd, 0) < 0 THEN
+    RAISE EXCEPTION 'Costs must be non-negative';
+  END IF;
+
+  SELECT billed_credits
+  INTO v_billed_credits
+  FROM public.jobs
+  WHERE id = p_job_id
+  FOR UPDATE;
+
+  IF v_billed_credits IS NULL THEN
+    RAISE EXCEPTION 'Job not found';
+  END IF;
+
+  v_revenue_usd := ROUND((v_billed_credits::numeric * p_credit_price_usd)::numeric, 6);
+
+  IF COALESCE(p_compute_cost_usd, 0) > 0 THEN
+    INSERT INTO public.job_costs (job_id, cost_type, amount_usd)
+    VALUES (p_job_id, 'compute', ROUND(p_compute_cost_usd::numeric, 6))
+    ON CONFLICT (job_id, cost_type)
+    DO UPDATE SET amount_usd = EXCLUDED.amount_usd;
+  END IF;
+
+  IF COALESCE(p_storage_cost_usd, 0) > 0 THEN
+    INSERT INTO public.job_costs (job_id, cost_type, amount_usd)
+    VALUES (p_job_id, 'storage', ROUND(p_storage_cost_usd::numeric, 6))
+    ON CONFLICT (job_id, cost_type)
+    DO UPDATE SET amount_usd = EXCLUDED.amount_usd;
+  END IF;
+
+  IF COALESCE(p_external_api_cost_usd, 0) > 0 THEN
+    INSERT INTO public.job_costs (job_id, cost_type, amount_usd)
+    VALUES (p_job_id, 'external_api', ROUND(p_external_api_cost_usd::numeric, 6))
+    ON CONFLICT (job_id, cost_type)
+    DO UPDATE SET amount_usd = EXCLUDED.amount_usd;
+  END IF;
+
+  UPDATE public.jobs
+  SET revenue_usd = v_revenue_usd
+  WHERE id = p_job_id;
+
+  RETURN QUERY
+  WITH summed AS (
+    SELECT COALESCE(SUM(amount_usd), 0)::numeric(10,6) AS summed_cost
+    FROM public.job_costs
+    WHERE job_id = p_job_id
+  )
+  SELECT
+    summed.summed_cost,
+    v_revenue_usd::numeric(10,6),
+    (v_revenue_usd - summed.summed_cost)::numeric(10,6)
+  FROM summed;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.finalize_job_economics(uuid, numeric, numeric, numeric, numeric) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.finalize_job_economics(uuid, numeric, numeric, numeric, numeric) FROM authenticated;
+GRANT EXECUTE ON FUNCTION public.finalize_job_economics(uuid, numeric, numeric, numeric, numeric) TO service_role;
+
+CREATE OR REPLACE VIEW public.admin_job_metrics AS
+SELECT
+  COUNT(*)::int AS total_jobs,
+  COUNT(*) FILTER (WHERE j.status = 'completed')::int AS completed,
+  COUNT(*) FILTER (WHERE j.status = 'failed')::int AS failed,
+  COUNT(*) FILTER (WHERE j.status = 'processing')::int AS processing,
+  COUNT(*) FILTER (WHERE j.status = 'queued')::int AS queued,
+  COALESCE(ROUND(AVG(j.execution_duration_ms) FILTER (WHERE j.execution_duration_ms IS NOT NULL)), 0)::int AS avg_execution_ms,
+  COALESCE(
+    ROUND((COUNT(*) FILTER (WHERE j.attempt_count > 1)::numeric / NULLIF(COUNT(*), 0)::numeric), 4),
+    0
+  ) AS retry_rate,
+  COALESCE(SUM(c.total_cost), 0)::numeric(12,6) AS total_cost_usd,
+  COALESCE(SUM(j.revenue_usd), 0)::numeric(12,6) AS total_revenue_usd,
+  COALESCE(SUM(j.revenue_usd), 0)::numeric(12,6) - COALESCE(SUM(c.total_cost), 0)::numeric(12,6) AS total_margin_usd,
+  COALESCE(
+    ROUND(
+      (
+        (COALESCE(SUM(j.revenue_usd), 0)::numeric - COALESCE(SUM(c.total_cost), 0)::numeric)
+        / NULLIF(COUNT(*) FILTER (WHERE j.status = 'completed'), 0)::numeric
+      ),
+      6
+    ),
+    0
+  )::numeric(12,6) AS avg_margin_per_job
+FROM public.jobs j
+LEFT JOIN (
+  SELECT job_id, SUM(amount_usd)::numeric(12,6) AS total_cost
+  FROM public.job_costs
+  GROUP BY job_id
+) c ON c.job_id = j.id;


### PR DESCRIPTION
### Motivation
- Add production-grade per-job cost tracking and unit-economics so each job records compute/storage/API costs, revenue, and margin for auditing and dashboards.
- Ensure idempotent, transaction-safe finalization so retries do not double-count costs and revenue updates remain consistent.

### Description
- Added migration `012_job_costs_and_unit_economics.sql` which creates `public.job_costs` (with `UNIQUE(job_id, cost_type)`), adds `jobs.revenue_usd` and `jobs.billed_credits`, and extends the `admin_job_metrics` view with `total_cost_usd`, `total_revenue_usd`, `total_margin_usd`, and `avg_margin_per_job`.
- Implemented `public.finalize_job_economics(...)` DB function that `FOR UPDATE` locks the job row, computes revenue from `billed_credits * p_credit_price_usd`, upserts per-type cost rows (`ON CONFLICT (job_id,cost_type)`), updates `jobs.revenue_usd`, and returns `total_cost_usd`, `revenue_usd`, and `margin_usd` in a single transaction.
- Persist billed credits at job creation by updating `create_video_job` to `INSERT INTO public.jobs (video_id, billed_credits)` so revenue can be derived later.
- Updated worker-consumer to compute compute-cost from `execution_duration_ms` (constant `COMPUTE_COST_PER_SECOND_USD`) and call the `finalize_job_economics` RPC on completion paths, while preserving existing completion guards and idempotency.
- Extended the admin API types and `/api/admin/metrics` response to include the new economics fields and kept all changes fully typed in worker and API code.

### Testing
- Ran full `npm run build` which failed in this environment due to Next.js prerender requiring Supabase env vars (build-time `supabaseUrl` error), so web build did not complete.
- Built the serverless workers with `npm run build --workspace @pat87creator/worker-api` and `npm run build --workspace @pat87creator/worker-consumer`, and both succeeded (worker builds exercised `wrangler deploy --dry-run`).
- Verified migration and SQL by adding `012_job_costs_and_unit_economics.sql` and performing static inspection of the created function, view, and new constraints to ensure idempotency and transactional behavior (no automated DB migration run in CI here).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a691dfff3c833192f7f8bf90b63d30)