### PR TITLE
Phase 19 — Atomic rate limiting & abuse protection for job creation

### DIFF
--- a/apps/web/app/api/jobs/create/route.ts
+++ b/apps/web/app/api/jobs/create/route.ts
@@ -9,6 +9,14 @@ type CreateJobRpcResponse = {
   error: { message: string } | null;
 };
 
+type RateLimitCode = 'jobs_per_minute' | 'concurrent_jobs' | 'daily_credits';
+
+type RateLimitErrorResponse = {
+  error: 'rate_limit_exceeded';
+  code: RateLimitCode;
+  message: string;
+};
+
 type JobQueueMessage = {
   job_id: string;
   user_id: string;
@@ -24,6 +32,7 @@ type RuntimeWithQueue = typeof globalThis & {
 };
 
 const VIDEO_JOB_COST = 10;
+const RATE_LIMIT_PREFIX = 'RATE_LIMIT_EXCEEDED|';
 
 const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
 const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
@@ -72,6 +81,28 @@ function enqueueJob(message: JobQueueMessage): void {
       message: error instanceof Error ? error.message : 'Unknown error'
     });
   });
+}
+
+function parseRateLimitError(message: string | undefined): RateLimitErrorResponse | null {
+  if (!message?.startsWith(RATE_LIMIT_PREFIX)) {
+    return null;
+  }
+
+  const [, code, userMessage] = message.split('|');
+
+  if (
+    code !== 'jobs_per_minute' &&
+    code !== 'concurrent_jobs' &&
+    code !== 'daily_credits'
+  ) {
+    return null;
+  }
+
+  return {
+    error: 'rate_limit_exceeded',
+    code,
+    message: userMessage ?? 'Rate limit exceeded'
+  };
 }
 
 export async function POST(request: Request) {
@@ -143,6 +174,11 @@ export async function POST(request: Request) {
       userId: user.id,
       message: rpcResponse.error?.message
     });
+
+    const rateLimitError = parseRateLimitError(rpcResponse.error?.message);
+    if (rateLimitError) {
+      return Response.json(rateLimitError, { status: 429 });
+    }
 
     const isInsufficientCredits =
       rpcResponse.error?.message?.toLowerCase().includes('insufficient credits') ?? false;

--- a/packages/db/migrations/013_atomic_rate_limiting.sql
+++ b/packages/db/migrations/013_atomic_rate_limiting.sql
@@ -1,0 +1,156 @@
+CREATE TABLE IF NOT EXISTS public.user_daily_usage (
+  user_id UUID NOT NULL REFERENCES public.users(id) ON DELETE CASCADE,
+  date DATE NOT NULL,
+  jobs_created INTEGER NOT NULL DEFAULT 0,
+  credits_spent INTEGER NOT NULL DEFAULT 0,
+  PRIMARY KEY (user_id, date)
+);
+
+CREATE TABLE IF NOT EXISTS public.rate_limit_config (
+  plan TEXT PRIMARY KEY,
+  max_jobs_per_minute INTEGER NOT NULL,
+  max_concurrent_jobs INTEGER NOT NULL,
+  max_daily_credits INTEGER NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  CHECK (max_jobs_per_minute > 0),
+  CHECK (max_concurrent_jobs > 0),
+  CHECK (max_daily_credits > 0)
+);
+
+INSERT INTO public.rate_limit_config (plan, max_jobs_per_minute, max_concurrent_jobs, max_daily_credits)
+VALUES ('default', 3, 2, 50)
+ON CONFLICT (plan) DO NOTHING;
+
+DROP TRIGGER IF EXISTS trg_rate_limit_config_set_updated_at ON public.rate_limit_config;
+
+CREATE TRIGGER trg_rate_limit_config_set_updated_at
+BEFORE UPDATE ON public.rate_limit_config
+FOR EACH ROW
+EXECUTE FUNCTION public.set_updated_at_timestamp();
+
+CREATE OR REPLACE FUNCTION public.create_video_job(
+  p_user_id uuid,
+  p_cost integer,
+  p_payload jsonb
+)
+RETURNS uuid
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_job_id uuid;
+  v_video_id uuid;
+  v_jobs_last_minute integer;
+  v_concurrent_jobs integer;
+  v_daily_credits_spent integer;
+  v_max_jobs_per_minute integer := 3;
+  v_max_concurrent_jobs integer := 2;
+  v_max_daily_credits integer := 50;
+BEGIN
+  IF p_user_id IS NULL THEN
+    RAISE EXCEPTION 'User id is required';
+  END IF;
+
+  IF p_cost IS NULL OR p_cost <= 0 THEN
+    RAISE EXCEPTION 'Cost must be greater than zero';
+  END IF;
+
+  IF p_payload IS NULL OR jsonb_typeof(p_payload) <> 'object' THEN
+    RAISE EXCEPTION 'Payload must be a JSON object';
+  END IF;
+
+  BEGIN
+    v_video_id := (p_payload ->> 'video_id')::uuid;
+  EXCEPTION
+    WHEN invalid_text_representation THEN
+      RAISE EXCEPTION 'Payload video_id must be a valid UUID';
+  END;
+
+  IF v_video_id IS NULL THEN
+    RAISE EXCEPTION 'Payload video_id is required';
+  END IF;
+
+  SELECT
+    max_jobs_per_minute,
+    max_concurrent_jobs,
+    max_daily_credits
+  INTO
+    v_max_jobs_per_minute,
+    v_max_concurrent_jobs,
+    v_max_daily_credits
+  FROM public.rate_limit_config
+  WHERE plan = 'default';
+
+  SELECT id
+  FROM public.users
+  WHERE id = p_user_id
+  FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'User not found';
+  END IF;
+
+  INSERT INTO public.user_daily_usage (user_id, date)
+  VALUES (p_user_id, CURRENT_DATE)
+  ON CONFLICT (user_id, date) DO NOTHING;
+
+  SELECT credits_spent
+  INTO v_daily_credits_spent
+  FROM public.user_daily_usage
+  WHERE user_id = p_user_id
+    AND date = CURRENT_DATE
+  FOR UPDATE;
+
+  SELECT COUNT(*)::integer
+  INTO v_jobs_last_minute
+  FROM public.jobs j
+  INNER JOIN public.videos v ON v.id = j.video_id
+  WHERE v.user_id = p_user_id
+    AND j.created_at > now() - INTERVAL '1 minute';
+
+  IF v_jobs_last_minute >= v_max_jobs_per_minute THEN
+    RAISE EXCEPTION 'RATE_LIMIT_EXCEEDED|jobs_per_minute|You have reached your per-minute job limit.';
+  END IF;
+
+  SELECT COUNT(*)::integer
+  INTO v_concurrent_jobs
+  FROM public.jobs j
+  INNER JOIN public.videos v ON v.id = j.video_id
+  WHERE v.user_id = p_user_id
+    AND j.status IN ('queued', 'processing');
+
+  IF v_concurrent_jobs >= v_max_concurrent_jobs THEN
+    RAISE EXCEPTION 'RATE_LIMIT_EXCEEDED|concurrent_jobs|You have reached your concurrent job limit.';
+  END IF;
+
+  IF (COALESCE(v_daily_credits_spent, 0) + p_cost) > v_max_daily_credits THEN
+    RAISE EXCEPTION 'RATE_LIMIT_EXCEEDED|daily_credits|You have reached your daily credit cap.';
+  END IF;
+
+  PERFORM set_config('request.jwt.claim.sub', p_user_id::text, true);
+
+  PERFORM public.deduct_credits(p_cost);
+
+  INSERT INTO public.jobs (video_id, billed_credits)
+  SELECT v.id, p_cost
+  FROM public.videos AS v
+  WHERE v.id = v_video_id
+    AND v.user_id = p_user_id
+  RETURNING id INTO v_job_id;
+
+  IF v_job_id IS NULL THEN
+    RAISE EXCEPTION 'Video not found for user';
+  END IF;
+
+  UPDATE public.user_daily_usage
+  SET
+    jobs_created = jobs_created + 1,
+    credits_spent = credits_spent + p_cost
+  WHERE user_id = p_user_id
+    AND date = CURRENT_DATE;
+
+  RETURN v_job_id;
+END;
+$$;


### PR DESCRIPTION
### Motivation
- Prevent job-creation abuse (per-minute spam, concurrent overload, daily credit drain) with server-enforced database-atomic checks. 
- Ensure checks are atomic and race-resistant while preserving existing credit deduction and idempotency semantics. 
- Apply production-safe default limits (`max_jobs_per_minute = 3`, `max_concurrent_jobs = 2`, `max_daily_credits = 50`).

### Description
- Add new DB migration `packages/db/migrations/013_atomic_rate_limiting.sql` that creates `user_daily_usage` (per-user daily counters) and optional `rate_limit_config` (plan-based limits seeded with `default` values) and replaces `public.create_video_job` with an atomic, lock-based implementation enforcing per-minute, concurrent, and daily limits inside the same transactional flow.
- The new `create_video_job` flow locks the relevant user row and `user_daily_usage` row, checks `jobs` created in the last minute, concurrent `queued`/`processing` jobs, and daily credits before calling `public.deduct_credits`, inserting the job, and updating daily counters to avoid race conditions.
- Update `apps/web/app/api/jobs/create/route.ts` to add typed rate-limit handling: parse DB-raised errors of the form `RATE_LIMIT_EXCEEDED|<code>|<message>` and return a structured `429` JSON body `{ error: "rate_limit_exceeded", code, message }` while preserving existing insufficient-credit (`402`) and generic error behavior.
- No AGENTS skill from `AGENTS.md` was used because the work consisted of direct application code and DB migration edits.

### Testing
- Ran `npm run build:web` which compiled and type-checked the updated route files successfully (route changes are type-safe). 
- The full Next.js build fails prerendering in this container due to missing runtime Supabase env (`supabaseUrl is required`) which is an environment limitation in this CI/context and not a code error. 
- The DB migration was created and not applied locally in this environment, so runtime DB verification (applying migration and integration tests) remains to be run in a staging environment with a real database.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a698580ca883319cbbcc902756f782)