### PR TITLE
Phase 20.5: Harden dashboard polling, optimistic jobs, toasts & UX safeguards

### DIFF
--- a/apps/web/app/dashboard/error.tsx
+++ b/apps/web/app/dashboard/error.tsx
@@ -1,0 +1,13 @@
+'use client';
+
+export default function DashboardError({ reset }: { error: Error & { digest?: string }; reset: () => void }) {
+  return (
+    <div style={{ padding: '1rem' }}>
+      <h2>Something went wrong in the dashboard.</h2>
+      <p>Please reload or try again.</p>
+      <button type="button" onClick={() => reset()}>
+        Reload
+      </button>
+    </div>
+  );
+}

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next';
 import { ReactNode } from 'react';
+import { ToastProvider } from '../components/ToastProvider';
 
 export const metadata: Metadata = {
   title: 'pat87creator',
@@ -9,7 +10,9 @@ export const metadata: Metadata = {
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (
     <html lang="en">
-      <body>{children}</body>
+      <body>
+        <ToastProvider>{children}</ToastProvider>
+      </body>
     </html>
   );
 }

--- a/apps/web/components/CreateVideoForm.tsx
+++ b/apps/web/components/CreateVideoForm.tsx
@@ -1,87 +1,25 @@
 'use client';
 
 import { FormEvent, useState } from 'react';
-import { supabase } from '../lib/supabase';
 
 type CreateVideoFormProps = {
-  onJobCreated: () => void;
+  onCreateJob: (payload: { prompt: string }) => Promise<boolean>;
+  isSubmitting: boolean;
+  cooldownSeconds: number;
 };
 
-type RateLimitCode = 'jobs_per_minute' | 'concurrent_jobs' | 'daily_credits';
-
-type RateLimitErrorResponse = {
-  error: 'rate_limit_exceeded';
-  code: RateLimitCode;
-};
-
-const RATE_LIMIT_MESSAGES: Record<RateLimitCode, string> = {
-  jobs_per_minute: 'Too many jobs submitted in a short time. Please wait a moment.',
-  concurrent_jobs: 'You already have the maximum number of active jobs. Wait for completion.',
-  daily_credits: 'Daily job cap reached for your current credit capacity.'
-};
-
-export function CreateVideoForm({ onJobCreated }: CreateVideoFormProps) {
+export function CreateVideoForm({ onCreateJob, isSubmitting, cooldownSeconds }: CreateVideoFormProps) {
   const [prompt, setPrompt] = useState('');
-  const [isSubmitting, setIsSubmitting] = useState(false);
-  const [message, setMessage] = useState('');
-  const [rateLimitedUntil, setRateLimitedUntil] = useState<number | null>(null);
 
-  const isRateLimitBlocked = rateLimitedUntil !== null && Date.now() < rateLimitedUntil;
+  const isRateLimited = cooldownSeconds > 0;
 
   const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
-    setMessage('');
 
-    if (isRateLimitBlocked) {
-      setMessage('Temporarily blocked due to rate limits. Please wait and try again.');
-      return;
+    const didCreate = await onCreateJob({ prompt });
+    if (didCreate) {
+      setPrompt('');
     }
-
-    setIsSubmitting(true);
-
-    const {
-      data: { session }
-    } = await supabase.auth.getSession();
-
-    if (!session?.access_token) {
-      setMessage('Session expired. Please log in again.');
-      setIsSubmitting(false);
-      return;
-    }
-
-    const response = await fetch('/api/jobs/create', {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: `Bearer ${session.access_token}`
-      },
-      body: JSON.stringify({ payload: { prompt } })
-    });
-
-    if (response.status === 429) {
-      const payload = (await response.json()) as RateLimitErrorResponse;
-      setMessage(RATE_LIMIT_MESSAGES[payload.code] ?? 'Rate limit exceeded. Try again later.');
-      setRateLimitedUntil(Date.now() + 15_000);
-      setIsSubmitting(false);
-      return;
-    }
-
-    if (response.status === 402) {
-      setMessage('Insufficient credits. Please add credits before creating another video.');
-      setIsSubmitting(false);
-      return;
-    }
-
-    if (!response.ok) {
-      setMessage('Something went wrong while creating the job. Please try again.');
-      setIsSubmitting(false);
-      return;
-    }
-
-    setPrompt('');
-    setMessage('Video job created successfully.');
-    setIsSubmitting(false);
-    onJobCreated();
   };
 
   return (
@@ -95,15 +33,14 @@ export function CreateVideoForm({ onJobCreated }: CreateVideoFormProps) {
           onChange={(event) => setPrompt(event.target.value)}
           rows={4}
           required
-          disabled={isSubmitting || isRateLimitBlocked}
+          disabled={isSubmitting || isRateLimited}
         />
         <div>
-          <button type="submit" disabled={isSubmitting || isRateLimitBlocked}>
-            {isSubmitting ? 'Creating...' : 'Create job'}
+          <button type="submit" disabled={isSubmitting || isRateLimited}>
+            {isSubmitting ? 'Creating...' : isRateLimited ? `Wait ${cooldownSeconds}s` : 'Create job'}
           </button>
         </div>
       </form>
-      {message ? <p>{message}</p> : null}
     </section>
   );
 }

--- a/apps/web/components/CreditBalance.tsx
+++ b/apps/web/components/CreditBalance.tsx
@@ -33,15 +33,8 @@ export function CreditBalance({ refreshKey }: CreditBalanceProps) {
       }
     });
 
-    if (response.status === 401) {
-      setErrorMessage('Session expired. Please log in again.');
-      setCredits(null);
-      setIsLoading(false);
-      return;
-    }
-
     if (!response.ok) {
-      setErrorMessage('Unable to load credits right now.');
+      setErrorMessage(response.status === 401 ? 'Session expired. Please log in again.' : 'Unable to load credits right now.');
       setCredits(null);
       setIsLoading(false);
       return;
@@ -57,7 +50,7 @@ export function CreditBalance({ refreshKey }: CreditBalanceProps) {
   }, [loadCredits, refreshKey]);
 
   if (isLoading) {
-    return <p>Credits: Loading...</p>;
+    return <div style={{ height: 24, width: 140, borderRadius: 8, background: '#f3f4f6', marginBottom: 12 }} />;
   }
 
   if (errorMessage) {

--- a/apps/web/components/DashboardClient.tsx
+++ b/apps/web/components/DashboardClient.tsx
@@ -1,22 +1,170 @@
 'use client';
 
-import { useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { CreateVideoForm } from './CreateVideoForm';
 import { CreditBalance } from './CreditBalance';
 import { JobTable } from './JobTable';
+import { useToast } from './ToastProvider';
+import { supabase } from '../lib/supabase';
+
+type JobPayload = { prompt: string };
+
+type OptimisticJob = {
+  tempId: string;
+  realJobId: string;
+  createdAt: string;
+};
+
+type RateLimitCode = 'jobs_per_minute' | 'concurrent_jobs' | 'daily_credits';
+
+type RateLimitErrorResponse = {
+  error: 'rate_limit_exceeded';
+  code: RateLimitCode;
+  message?: string;
+};
+
+const RATE_LIMIT_MESSAGES: Record<RateLimitCode, string> = {
+  jobs_per_minute: 'Too many jobs submitted in a short time. Please wait.',
+  concurrent_jobs: 'You already have the maximum number of active jobs.',
+  daily_credits: 'Daily job cap reached for your current credit capacity.'
+};
 
 export function DashboardClient() {
+  const { pushToast } = useToast();
   const [refreshKey, setRefreshKey] = useState(0);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [cooldownUntil, setCooldownUntil] = useState<number | null>(null);
+  const [payloadByJobId, setPayloadByJobId] = useState<Record<string, JobPayload>>({});
+  const [optimisticJobs, setOptimisticJobs] = useState<OptimisticJob[]>([]);
+  const [tick, setTick] = useState(0);
 
-  const triggerRefresh = () => {
-    setRefreshKey((current) => current + 1);
-  };
+  useEffect(() => {
+    if (!cooldownUntil || Date.now() >= cooldownUntil) {
+      return;
+    }
+
+    const timer = window.setInterval(() => setTick((current) => current + 1), 1000);
+
+    return () => window.clearInterval(timer);
+  }, [cooldownUntil, tick]);
+
+  const cooldownSeconds = useMemo(() => {
+    if (!cooldownUntil) {
+      return 0;
+    }
+
+    return Math.max(0, Math.ceil((cooldownUntil - Date.now()) / 1000));
+  }, [cooldownUntil, tick]);
+
+  const createJob = useCallback(
+    async (payload: JobPayload): Promise<boolean> => {
+      if (isSubmitting) {
+        return false;
+      }
+
+      if (cooldownUntil && Date.now() < cooldownUntil) {
+        pushToast({ message: `Rate limited. Try again in ${cooldownSeconds}s.`, tone: 'error' });
+        return false;
+      }
+
+      setIsSubmitting(true);
+
+      const {
+        data: { session }
+      } = await supabase.auth.getSession();
+
+      if (!session?.access_token) {
+        pushToast({ message: 'Session expired. Please log in again.', tone: 'error' });
+        setIsSubmitting(false);
+        return false;
+      }
+
+      const response = await fetch('/api/jobs/create', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${session.access_token}`
+        },
+        body: JSON.stringify({ payload })
+      });
+
+      if (response.status === 429) {
+        const error = (await response.json()) as RateLimitErrorResponse;
+        setCooldownUntil(Date.now() + 10_000);
+        pushToast({ message: RATE_LIMIT_MESSAGES[error.code] ?? 'Rate limit exceeded.', tone: 'error' });
+        setIsSubmitting(false);
+        return false;
+      }
+
+      if (response.status === 402) {
+        pushToast({ message: 'Insufficient credits. Please add credits before creating another job.', tone: 'error' });
+        setIsSubmitting(false);
+        return false;
+      }
+
+      if (!response.ok) {
+        pushToast({ message: 'Something went wrong while creating the job.', tone: 'error' });
+        setIsSubmitting(false);
+        return false;
+      }
+
+      const { job_id } = (await response.json()) as { job_id: string };
+      const tempId = `temp-${Date.now()}`;
+
+      setPayloadByJobId((current) => ({ ...current, [job_id]: payload }));
+      setOptimisticJobs((current) => [
+        { tempId, realJobId: job_id, createdAt: new Date().toISOString() },
+        ...current
+      ]);
+      setRefreshKey((current) => current + 1);
+      pushToast({ message: 'Job created successfully.', tone: 'success' });
+      setIsSubmitting(false);
+      return true;
+    },
+    [cooldownSeconds, cooldownUntil, isSubmitting, pushToast]
+  );
+
+  const handleJobTerminalStatus = useCallback(
+    (status: 'completed' | 'failed') => {
+      if (status === 'completed') {
+        pushToast({ message: 'Job completed.', tone: 'success' });
+      } else {
+        pushToast({ message: 'Job failed.', tone: 'error' });
+      }
+
+      setRefreshKey((current) => current + 1);
+    },
+    [pushToast]
+  );
+
+  const handleRealJobsSeen = useCallback((jobIds: string[]) => {
+    setOptimisticJobs((current) => current.filter((job) => !jobIds.includes(job.realJobId)));
+  }, []);
+
+  const handleRetry = useCallback(
+    async (jobId: string) => {
+      const payload = payloadByJobId[jobId];
+      if (!payload) {
+        pushToast({ message: 'Cannot retry this job because original payload is unavailable.', tone: 'error' });
+        return;
+      }
+
+      await createJob(payload);
+    },
+    [createJob, payloadByJobId, pushToast]
+  );
 
   return (
     <>
       <CreditBalance refreshKey={refreshKey} />
-      <CreateVideoForm onJobCreated={triggerRefresh} />
-      <JobTable refreshKey={refreshKey} />
+      <CreateVideoForm onCreateJob={createJob} isSubmitting={isSubmitting} cooldownSeconds={cooldownSeconds} />
+      <JobTable
+        refreshKey={refreshKey}
+        optimisticJobs={optimisticJobs}
+        onRealJobsSeen={handleRealJobsSeen}
+        onRetry={handleRetry}
+        onTerminalStatus={handleJobTerminalStatus}
+      />
     </>
   );
 }

--- a/apps/web/components/JobTable.tsx
+++ b/apps/web/components/JobTable.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { supabase } from '../lib/supabase';
 import { StatusBadge } from './StatusBadge';
 
@@ -18,8 +18,18 @@ type JobsResponse = {
   data: JobListItem[];
 };
 
+type OptimisticJob = {
+  tempId: string;
+  realJobId: string;
+  createdAt: string;
+};
+
 type JobTableProps = {
   refreshKey: number;
+  optimisticJobs: OptimisticJob[];
+  onRealJobsSeen: (jobIds: string[]) => void;
+  onRetry: (jobId: string) => Promise<void>;
+  onTerminalStatus: (status: 'completed' | 'failed') => void;
 };
 
 const POLL_INTERVAL_MS = 7000;
@@ -28,14 +38,23 @@ function formatDate(value: string): string {
   return new Date(value).toLocaleString();
 }
 
-export function JobTable({ refreshKey }: JobTableProps) {
+export function JobTable({
+  refreshKey,
+  optimisticJobs,
+  onRealJobsSeen,
+  onRetry,
+  onTerminalStatus
+}: JobTableProps) {
   const [jobs, setJobs] = useState<JobListItem[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [errorMessage, setErrorMessage] = useState('');
+  const [downloadLoadingById, setDownloadLoadingById] = useState<Record<string, boolean>>({});
+  const [retryLoadingById, setRetryLoadingById] = useState<Record<string, boolean>>({});
+  const prevStatusByIdRef = useRef<Record<string, JobStatus>>({});
 
   const hasActiveJobs = useMemo(
-    () => jobs.some((job) => job.status === 'queued' || job.status === 'processing'),
-    [jobs]
+    () => jobs.some((job) => job.status === 'queued' || job.status === 'processing') || optimisticJobs.length > 0,
+    [jobs, optimisticJobs.length]
   );
 
   const loadJobs = useCallback(async () => {
@@ -62,10 +81,27 @@ export function JobTable({ refreshKey }: JobTableProps) {
     }
 
     const payload = (await response.json()) as JobsResponse;
+
+    const seenIds = payload.data.map((job) => job.id);
+    onRealJobsSeen(seenIds);
+
+    const previousStatuses = prevStatusByIdRef.current;
+    for (const job of payload.data) {
+      const previousStatus = previousStatuses[job.id];
+      if (previousStatus && previousStatus !== job.status && (job.status === 'completed' || job.status === 'failed')) {
+        onTerminalStatus(job.status);
+      }
+    }
+
+    prevStatusByIdRef.current = payload.data.reduce<Record<string, JobStatus>>((acc, job) => {
+      acc[job.id] = job.status;
+      return acc;
+    }, {});
+
     setJobs(payload.data);
     setErrorMessage('');
     setIsLoading(false);
-  }, []);
+  }, [onRealJobsSeen, onTerminalStatus]);
 
   useEffect(() => {
     setIsLoading(true);
@@ -77,20 +113,61 @@ export function JobTable({ refreshKey }: JobTableProps) {
       return;
     }
 
-    const timer = setInterval(() => {
+    const timer = window.setInterval(() => {
       void loadJobs();
     }, POLL_INTERVAL_MS);
 
     return () => {
-      clearInterval(timer);
+      window.clearInterval(timer);
     };
   }, [hasActiveJobs, loadJobs]);
+
+  const visibleJobs = useMemo(() => {
+    const resolvedJobIds = new Set(jobs.map((job) => job.id));
+    const optimisticRows: JobListItem[] = optimisticJobs
+      .filter((job) => !resolvedJobIds.has(job.realJobId))
+      .map((job) => ({
+        id: job.tempId,
+        status: 'queued',
+        created_at: job.createdAt,
+        video_url: null,
+        error_message: null
+      }));
+
+    return [...optimisticRows, ...jobs];
+  }, [jobs, optimisticJobs]);
+
+  const handleDownload = useCallback((job: JobListItem) => {
+    if (!job.video_url || downloadLoadingById[job.id]) {
+      return;
+    }
+
+    setDownloadLoadingById((current) => ({ ...current, [job.id]: true }));
+
+    try {
+      const anchor = document.createElement('a');
+      anchor.href = job.video_url;
+      anchor.target = '_blank';
+      anchor.rel = 'noreferrer';
+      anchor.click();
+    } finally {
+      window.setTimeout(() => {
+        setDownloadLoadingById((current) => ({ ...current, [job.id]: false }));
+      }, 1000);
+    }
+  }, [downloadLoadingById]);
+
+  const handleRetry = useCallback(async (jobId: string) => {
+    setRetryLoadingById((current) => ({ ...current, [jobId]: true }));
+    await onRetry(jobId);
+    setRetryLoadingById((current) => ({ ...current, [jobId]: false }));
+  }, [onRetry]);
 
   if (isLoading) {
     return (
       <section>
         <h2>Jobs</h2>
-        <p>Loading jobs...</p>
+        <div style={{ height: 120, borderRadius: 8, background: '#f3f4f6' }} />
       </section>
     );
   }
@@ -104,7 +181,7 @@ export function JobTable({ refreshKey }: JobTableProps) {
     );
   }
 
-  if (jobs.length === 0) {
+  if (visibleJobs.length === 0) {
     return (
       <section>
         <h2>Jobs</h2>
@@ -123,11 +200,12 @@ export function JobTable({ refreshKey }: JobTableProps) {
             <th>Status</th>
             <th>Duration</th>
             <th>Download</th>
+            <th>Retry</th>
             <th>Error</th>
           </tr>
         </thead>
         <tbody>
-          {jobs.map((job) => (
+          {visibleJobs.map((job) => (
             <tr key={job.id}>
               <td>{formatDate(job.created_at)}</td>
               <td>
@@ -135,10 +213,27 @@ export function JobTable({ refreshKey }: JobTableProps) {
               </td>
               <td>—</td>
               <td>
-                {job.status === 'completed' && job.video_url ? (
-                  <a href={job.video_url} target="_blank" rel="noreferrer">
-                    Download
-                  </a>
+                {job.status === 'completed' ? (
+                  <button
+                    type="button"
+                    onClick={() => handleDownload(job)}
+                    disabled={!job.video_url || Boolean(downloadLoadingById[job.id])}
+                  >
+                    {downloadLoadingById[job.id] ? 'Opening...' : 'Download'}
+                  </button>
+                ) : (
+                  '—'
+                )}
+              </td>
+              <td>
+                {job.status === 'failed' ? (
+                  <button
+                    type="button"
+                    onClick={() => void handleRetry(job.id)}
+                    disabled={Boolean(retryLoadingById[job.id])}
+                  >
+                    {retryLoadingById[job.id] ? 'Retrying...' : 'Retry'}
+                  </button>
                 ) : (
                   '—'
                 )}

--- a/apps/web/components/ToastProvider.tsx
+++ b/apps/web/components/ToastProvider.tsx
@@ -1,0 +1,70 @@
+'use client';
+
+import { createContext, ReactNode, useCallback, useContext, useMemo, useState } from 'react';
+
+type ToastTone = 'success' | 'error' | 'info';
+
+type ToastInput = {
+  message: string;
+  tone?: ToastTone;
+  durationMs?: number;
+};
+
+type ToastItem = ToastInput & { id: string };
+
+type ToastContextValue = {
+  pushToast: (input: ToastInput) => void;
+};
+
+const ToastContext = createContext<ToastContextValue | null>(null);
+
+export function ToastProvider({ children }: { children: ReactNode }) {
+  const [toasts, setToasts] = useState<ToastItem[]>([]);
+
+  const removeToast = useCallback((id: string) => {
+    setToasts((current) => current.filter((toast) => toast.id !== id));
+  }, []);
+
+  const pushToast = useCallback(
+    ({ message, tone = 'info', durationMs = 3500 }: ToastInput) => {
+      const id = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+      setToasts((current) => [...current, { id, message, tone, durationMs }]);
+      window.setTimeout(() => removeToast(id), durationMs);
+    },
+    [removeToast]
+  );
+
+  const value = useMemo(() => ({ pushToast }), [pushToast]);
+
+  return (
+    <ToastContext.Provider value={value}>
+      {children}
+      <div style={{ position: 'fixed', right: 16, top: 16, display: 'grid', gap: 8, zIndex: 1000 }}>
+        {toasts.map((toast) => (
+          <div
+            key={toast.id}
+            style={{
+              padding: '0.75rem 1rem',
+              borderRadius: 8,
+              color: '#111827',
+              border: '1px solid #e5e7eb',
+              background: toast.tone === 'success' ? '#dcfce7' : toast.tone === 'error' ? '#fee2e2' : '#eff6ff'
+            }}
+          >
+            {toast.message}
+          </div>
+        ))}
+      </div>
+    </ToastContext.Provider>
+  );
+}
+
+export function useToast() {
+  const value = useContext(ToastContext);
+
+  if (!value) {
+    throw new Error('useToast must be used within ToastProvider');
+  }
+
+  return value;
+}


### PR DESCRIPTION
### Motivation
- Stabilize the dashboard UI for public beta by eliminating noisy background polling, preventing double submissions, and improving perceived responsiveness. 
- Add a lightweight safety layer (toasts, error boundary, retries, skeletons) to make the app resilient under rapid clicks and API failures.

### Description
- Added a global toast system (`apps/web/components/ToastProvider.tsx` + `useToast()`) and mounted it in the root layout so actions can emit non-blocking success/error/rate-limit notifications. 
- Centralized and hardened job creation in `DashboardClient` to enforce a single in-flight submission, apply a rate-limit cooldown with countdown, insert an optimistic `queued` row, and persist payloads locally for safe retries. 
- Reworked `JobTable` to poll only while active jobs or optimistic jobs exist, clean up intervals on unmount/stop, merge optimistic rows with real jobs when seen, detect terminal status transitions to trigger toasts and credit refresh, add a retry button for failed jobs that replays the original payload, and guard downloads against rapid repeated clicks. 
- Replaced flashing loading text with skeleton placeholders in `CreditBalance` and `JobTable`, added a dashboard route-level error boundary (`app/dashboard/error.tsx`), and ensured credits remain backend-sourced with refetches on job lifecycle events (no optimistic credit mutation or backend contract changes).

### Testing
- Ran type-check: `npx tsc --noEmit -p apps/web/tsconfig.json` (passed without type errors). 
- Production web build: `npm run build:web` (Next.js build completed successfully). 
- Full workspace build: `npm run build` (completed successfully, worker dry-run steps included). 
- Dev + UI validation: attempted `next dev` and a Playwright capture, the dev server started but the headless Chromium process crashed in this environment (SIGSEGV) so a screenshot could not be produced; the runtime crash is environmental and does not indicate frontend regressions in the code changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a6b9c1ec2483319d111ba470bf7189)