### PR TITLE
Phase 21 follow-up: env/runtime hardening, safe errors, and structured logging

### DIFF
--- a/apps/web/app/api/_lib/safeHandler.ts
+++ b/apps/web/app/api/_lib/safeHandler.ts
@@ -1,0 +1,27 @@
+import { log } from '@pat87creator/logger';
+import { isProd } from '../../../lib/runtime';
+
+type Handler = (request: Request) => Promise<Response>;
+
+export function withSafeApiHandler(route: string, handler: Handler): Handler {
+  return async (request: Request) => {
+    try {
+      return await handler(request);
+    } catch (error) {
+      log('error', 'Unhandled API error', {
+        route,
+        method: request.method,
+        error: error instanceof Error ? error.message : 'unknown_error'
+      });
+
+      if (!isProd) {
+        log('debug', 'API error details', {
+          route,
+          stack: error instanceof Error ? error.stack : 'non_error_thrown'
+        });
+      }
+
+      return Response.json({ error: 'internal_server_error' }, { status: 500 });
+    }
+  };
+}

--- a/apps/web/app/api/credits/route.ts
+++ b/apps/web/app/api/credits/route.ts
@@ -1,18 +1,13 @@
 import { createClient } from '@supabase/supabase-js';
+import { getRequiredEnv } from '@pat87creator/config/env';
+import { withSafeApiHandler } from '../_lib/safeHandler';
 
 type CreditRow = {
   credits_remaining: number | null;
 };
 
-const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
-const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
-
-function missingEnvResponse(name: string) {
-  return Response.json(
-    { error: `Missing required environment variable: ${name}` },
-    { status: 500 }
-  );
-}
+const supabaseUrl = getRequiredEnv('NEXT_PUBLIC_SUPABASE_URL');
+const supabaseAnonKey = getRequiredEnv('NEXT_PUBLIC_SUPABASE_ANON_KEY');
 
 function getBearerToken(request: Request): string | null {
   const authorizationHeader = request.headers.get('authorization');
@@ -23,15 +18,7 @@ function getBearerToken(request: Request): string | null {
   return authorizationHeader.slice('Bearer '.length).trim() || null;
 }
 
-export async function GET(request: Request) {
-  if (!supabaseUrl) {
-    return missingEnvResponse('NEXT_PUBLIC_SUPABASE_URL');
-  }
-
-  if (!supabaseAnonKey) {
-    return missingEnvResponse('NEXT_PUBLIC_SUPABASE_ANON_KEY');
-  }
-
+export const GET = withSafeApiHandler('/api/credits', async (request: Request) => {
   const accessToken = getBearerToken(request);
   if (!accessToken) {
     return Response.json({ error: 'Unauthorized' }, { status: 401 });
@@ -69,4 +56,4 @@ export async function GET(request: Request) {
   }
 
   return Response.json({ credits_remaining: data?.credits_remaining ?? 0 }, { status: 200 });
-}
+});

--- a/apps/web/app/api/jobs/create/route.ts
+++ b/apps/web/app/api/jobs/create/route.ts
@@ -1,4 +1,7 @@
 import { createClient } from '@supabase/supabase-js';
+import { getRequiredEnv } from '@pat87creator/config/env';
+import { log } from '@pat87creator/logger';
+import { withSafeApiHandler } from '../../_lib/safeHandler';
 
 type CreateJobRequest = {
   payload?: unknown;
@@ -34,16 +37,9 @@ type RuntimeWithQueue = typeof globalThis & {
 const VIDEO_JOB_COST = 10;
 const RATE_LIMIT_PREFIX = 'RATE_LIMIT_EXCEEDED|';
 
-const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
-const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
-const supabaseServiceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
-
-function missingEnvResponse(name: string) {
-  return Response.json(
-    { error: `Missing required environment variable: ${name}` },
-    { status: 500 }
-  );
-}
+const supabaseUrl = getRequiredEnv('NEXT_PUBLIC_SUPABASE_URL');
+const supabaseAnonKey = getRequiredEnv('NEXT_PUBLIC_SUPABASE_ANON_KEY');
+const supabaseServiceRoleKey = getRequiredEnv('SUPABASE_SERVICE_ROLE_KEY');
 
 function getBearerToken(request: Request): string | null {
   const authorizationHeader = request.headers.get('authorization');
@@ -68,17 +64,16 @@ function enqueueJob(message: JobQueueMessage): void {
   const queue = getQueueBinding();
 
   if (!queue) {
-    console.error('Queue binding VIDEO_JOB_QUEUE is not available', {
-      jobId: message.job_id
-    });
+    log('error', 'Queue binding unavailable', { route: '/api/jobs/create', job_id: message.job_id });
     return;
   }
 
   void queue.send(message).catch((error: unknown) => {
-    console.error('Failed to enqueue video job', {
-      jobId: message.job_id,
-      userId: message.user_id,
-      message: error instanceof Error ? error.message : 'Unknown error'
+    log('error', 'Failed to enqueue video job', {
+      route: '/api/jobs/create',
+      job_id: message.job_id,
+      user_id: message.user_id,
+      error: error instanceof Error ? error.message : 'unknown_error'
     });
   });
 }
@@ -90,11 +85,7 @@ function parseRateLimitError(message: string | undefined): RateLimitErrorRespons
 
   const [, code, userMessage] = message.split('|');
 
-  if (
-    code !== 'jobs_per_minute' &&
-    code !== 'concurrent_jobs' &&
-    code !== 'daily_credits'
-  ) {
+  if (code !== 'jobs_per_minute' && code !== 'concurrent_jobs' && code !== 'daily_credits') {
     return null;
   }
 
@@ -105,19 +96,7 @@ function parseRateLimitError(message: string | undefined): RateLimitErrorRespons
   };
 }
 
-export async function POST(request: Request) {
-  if (!supabaseUrl) {
-    return missingEnvResponse('NEXT_PUBLIC_SUPABASE_URL');
-  }
-
-  if (!supabaseAnonKey) {
-    return missingEnvResponse('NEXT_PUBLIC_SUPABASE_ANON_KEY');
-  }
-
-  if (!supabaseServiceRoleKey) {
-    return missingEnvResponse('SUPABASE_SERVICE_ROLE_KEY');
-  }
-
+export const POST = withSafeApiHandler('/api/jobs/create', async (request: Request) => {
   const accessToken = getBearerToken(request);
   if (!accessToken) {
     return Response.json({ error: 'Unauthorized' }, { status: 401 });
@@ -170,9 +149,10 @@ export async function POST(request: Request) {
   })) as CreateJobRpcResponse;
 
   if (rpcResponse.error || !rpcResponse.data) {
-    console.error('create_video_job RPC failed', {
-      userId: user.id,
-      message: rpcResponse.error?.message
+    log('warn', 'create_video_job RPC failed', {
+      route: '/api/jobs/create',
+      user_id: user.id,
+      error: rpcResponse.error?.message ?? 'unknown_error'
     });
 
     const rateLimitError = parseRateLimitError(rpcResponse.error?.message);
@@ -199,4 +179,4 @@ export async function POST(request: Request) {
   });
 
   return Response.json({ job_id: jobId }, { status: 200 });
-}
+});

--- a/apps/web/app/api/jobs/route.ts
+++ b/apps/web/app/api/jobs/route.ts
@@ -1,4 +1,7 @@
 import { createClient } from '@supabase/supabase-js';
+import { getRequiredEnv } from '@pat87creator/config/env';
+import { log } from '@pat87creator/logger';
+import { withSafeApiHandler } from '../_lib/safeHandler';
 
 type JobStatus = 'queued' | 'processing' | 'completed' | 'failed';
 
@@ -37,16 +40,9 @@ const DEFAULT_LIMIT = 10;
 const MAX_LIMIT = 100;
 const DEFAULT_ARTIFACT_BUCKET = 'videos';
 
-const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
-const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+const supabaseUrl = getRequiredEnv('NEXT_PUBLIC_SUPABASE_URL');
+const supabaseAnonKey = getRequiredEnv('NEXT_PUBLIC_SUPABASE_ANON_KEY');
 const artifactBucket = process.env.SUPABASE_ARTIFACT_BUCKET ?? DEFAULT_ARTIFACT_BUCKET;
-
-function missingEnvResponse(name: string) {
-  return Response.json(
-    { error: `Missing required environment variable: ${name}` },
-    { status: 500 }
-  );
-}
 
 function getBearerToken(request: Request): string | null {
   const authorizationHeader = request.headers.get('authorization');
@@ -164,15 +160,7 @@ function toVideoUrl(client: StoragePublicUrlClient, job: JobRow): string | null 
   return data.publicUrl ?? null;
 }
 
-export async function GET(request: Request) {
-  if (!supabaseUrl) {
-    return missingEnvResponse('NEXT_PUBLIC_SUPABASE_URL');
-  }
-
-  if (!supabaseAnonKey) {
-    return missingEnvResponse('NEXT_PUBLIC_SUPABASE_ANON_KEY');
-  }
-
+export const GET = withSafeApiHandler('/api/jobs', async (request: Request) => {
   const accessToken = getBearerToken(request);
   if (!accessToken) {
     return Response.json({ error: 'Unauthorized' }, { status: 401 });
@@ -227,10 +215,7 @@ export async function GET(request: Request) {
   const { data, count, error } = await query.returns<(JobRow & { videos: { user_id: string } })[]>();
 
   if (error) {
-    console.error('Failed to fetch jobs', {
-      userId: user.id,
-      message: error.message
-    });
+    log('error', 'Failed to fetch jobs', { route: '/api/jobs', user_id: user.id, error: error.message });
 
     return Response.json({ error: 'Failed to fetch jobs' }, { status: 500 });
   }
@@ -257,4 +242,4 @@ export async function GET(request: Request) {
   };
 
   return Response.json(payload, { status: 200 });
-}
+});

--- a/apps/web/app/api/stripe/create-checkout-session/route.ts
+++ b/apps/web/app/api/stripe/create-checkout-session/route.ts
@@ -1,28 +1,23 @@
 import { createClient } from '@supabase/supabase-js';
+import { getRequiredEnv } from '@pat87creator/config/env';
+import { withSafeApiHandler } from '../../_lib/safeHandler';
 import Stripe from 'stripe';
 
 type CreateCheckoutSessionRequest = {
   credits?: unknown;
 };
 
-const stripeSecretKey = process.env.STRIPE_SECRET_KEY;
+const stripeSecretKey = getRequiredEnv('STRIPE_SECRET_KEY');
 const appUrl = process.env.NEXT_PUBLIC_APP_URL;
-const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
-const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+const supabaseUrl = getRequiredEnv('NEXT_PUBLIC_SUPABASE_URL');
+const supabaseAnonKey = getRequiredEnv('NEXT_PUBLIC_SUPABASE_ANON_KEY');
 
-const stripe = new Stripe(stripeSecretKey ?? '', {
+const stripe = new Stripe(stripeSecretKey, {
   apiVersion: '2024-06-20'
 });
 
 const MIN_CREDITS = 1;
 const MAX_CREDITS = 100_000;
-
-function missingEnvResponse(name: string) {
-  return Response.json(
-    { error: `Missing required environment variable: ${name}` },
-    { status: 500 }
-  );
-}
 
 function parseCredits(input: unknown): number | null {
   if (typeof input !== 'number' || !Number.isInteger(input)) {
@@ -45,21 +40,9 @@ function getBearerToken(request: Request): string | null {
   return authorizationHeader.slice('Bearer '.length).trim() || null;
 }
 
-export async function POST(request: Request) {
-  if (!stripeSecretKey) {
-    return missingEnvResponse('STRIPE_SECRET_KEY');
-  }
-
+export const POST = withSafeApiHandler('/api/stripe/create-checkout-session', async (request: Request) => {
   if (!appUrl) {
-    return missingEnvResponse('NEXT_PUBLIC_APP_URL');
-  }
-
-  if (!supabaseUrl) {
-    return missingEnvResponse('NEXT_PUBLIC_SUPABASE_URL');
-  }
-
-  if (!supabaseAnonKey) {
-    return missingEnvResponse('NEXT_PUBLIC_SUPABASE_ANON_KEY');
+    return Response.json({ error: 'Missing required environment variable: NEXT_PUBLIC_APP_URL' }, { status: 500 });
   }
 
   const accessToken = getBearerToken(request);
@@ -107,8 +90,6 @@ export async function POST(request: Request) {
     );
   }
 
-  const amountCents = credits;
-
   const session = await stripe.checkout.sessions.create({
     mode: 'payment',
     success_url: `${appUrl}/?checkout=success`,
@@ -118,7 +99,7 @@ export async function POST(request: Request) {
         quantity: 1,
         price_data: {
           currency: 'usd',
-          unit_amount: amountCents,
+          unit_amount: credits,
           product_data: {
             name: `${credits} credits`
           }
@@ -140,4 +121,4 @@ export async function POST(request: Request) {
   }
 
   return Response.json({ url: session.url }, { status: 200 });
-}
+});

--- a/apps/web/app/api/stripe/webhook/route.ts
+++ b/apps/web/app/api/stripe/webhook/route.ts
@@ -1,38 +1,32 @@
 import { createClient } from '@supabase/supabase-js';
+import { getRequiredEnv } from '@pat87creator/config/env';
+import { log } from '@pat87creator/logger';
+import { withSafeApiHandler } from '../../_lib/safeHandler';
 import Stripe from 'stripe';
 
-const stripeSecretKey = process.env.STRIPE_SECRET_KEY;
-const stripeWebhookSecret = process.env.STRIPE_WEBHOOK_SECRET;
-const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
-const supabaseServiceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+const stripeSecretKey = getRequiredEnv('STRIPE_SECRET_KEY');
+const stripeWebhookSecret = getRequiredEnv('STRIPE_WEBHOOK_SECRET');
+const supabaseUrl = getRequiredEnv('NEXT_PUBLIC_SUPABASE_URL');
+const supabaseServiceRoleKey = getRequiredEnv('SUPABASE_SERVICE_ROLE_KEY');
 
-const stripe = new Stripe(stripeSecretKey ?? '', {
+const stripe = new Stripe(stripeSecretKey, {
   apiVersion: '2024-06-20'
 });
 
-function missingEnvResponse(name: string) {
-  return new Response(`Missing required environment variable: ${name}`, { status: 500 });
+export async function GET() {
+  return new Response('Method not allowed', { status: 405 });
 }
 
-export async function POST(request: Request) {
-  if (!stripeSecretKey) {
-    return missingEnvResponse('STRIPE_SECRET_KEY');
-  }
-
-  if (!stripeWebhookSecret) {
-    return missingEnvResponse('STRIPE_WEBHOOK_SECRET');
-  }
-
-  if (!supabaseUrl) {
-    return missingEnvResponse('NEXT_PUBLIC_SUPABASE_URL');
-  }
-
-  if (!supabaseServiceRoleKey) {
-    return missingEnvResponse('SUPABASE_SERVICE_ROLE_KEY');
+export const POST = withSafeApiHandler('/api/stripe/webhook', async (request: Request) => {
+  const contentType = request.headers.get('content-type') ?? '';
+  if (!contentType.toLowerCase().startsWith('application/json')) {
+    log('warn', 'Rejected Stripe webhook invalid content-type', { route: '/api/stripe/webhook', content_type: contentType });
+    return new Response('Invalid content-type', { status: 415 });
   }
 
   const signature = request.headers.get('stripe-signature');
   if (!signature) {
+    log('warn', 'Rejected Stripe webhook missing signature', { route: '/api/stripe/webhook' });
     return new Response('Missing Stripe signature header', { status: 400 });
   }
 
@@ -42,13 +36,11 @@ export async function POST(request: Request) {
   try {
     event = stripe.webhooks.constructEvent(rawBody, signature, stripeWebhookSecret);
   } catch {
+    log('warn', 'Stripe webhook signature verification failed', { route: '/api/stripe/webhook' });
     return new Response('Invalid Stripe signature', { status: 400 });
   }
 
-  if (
-    event.type !== 'checkout.session.completed' &&
-    event.type !== 'payment_intent.succeeded'
-  ) {
+  if (event.type !== 'checkout.session.completed' && event.type !== 'payment_intent.succeeded') {
     return new Response('Ignored event', { status: 200 });
   }
 
@@ -86,8 +78,8 @@ export async function POST(request: Request) {
   });
 
   if (error) {
-    return new Response('Webhook handled', { status: 200 });
+    log('warn', 'Stripe webhook process_stripe_payment RPC failed', { route: '/api/stripe/webhook', provider_reference: event.id });
   }
 
   return new Response('Webhook handled', { status: 200 });
-}
+});

--- a/apps/web/app/error.tsx
+++ b/apps/web/app/error.tsx
@@ -1,0 +1,29 @@
+'use client';
+
+import { useEffect } from 'react';
+
+export default function GlobalError({
+  error,
+  reset
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    void error;
+  }, [error]);
+
+  return (
+    <html>
+      <body>
+        <main style={{ padding: 24, fontFamily: 'sans-serif', textAlign: 'center' }}>
+          <h1>Something went wrong</h1>
+          <p>We hit an unexpected error. Please refresh and try again.</p>
+          <button onClick={() => reset()} style={{ padding: '8px 16px', cursor: 'pointer' }}>
+            Reload
+          </button>
+        </main>
+      </body>
+    </html>
+  );
+}

--- a/apps/web/lib/runtime.ts
+++ b/apps/web/lib/runtime.ts
@@ -1,0 +1,2 @@
+export const isProd = process.env.NODE_ENV === 'production';
+export const isDev = !isProd;

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -5,13 +5,16 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
-    "start": "next start"
+    "start": "next start",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "next": "14.2.12",
     "react": "18.3.1",
     "react-dom": "18.3.1",
-    "stripe": "^16.10.0"
+    "stripe": "^16.10.0",
+    "@pat87creator/config": "0.1.0",
+    "@pat87creator/logger": "0.1.0"
   },
   "devDependencies": {
     "typescript": "5.5.4",

--- a/apps/worker-api/package.json
+++ b/apps/worker-api/package.json
@@ -7,5 +7,9 @@
   },
   "devDependencies": {
     "wrangler": "3.72.0"
+  },
+  "dependencies": {
+    "@pat87creator/config": "0.1.0",
+    "@pat87creator/logger": "0.1.0"
   }
 }

--- a/apps/worker-api/src/index.ts
+++ b/apps/worker-api/src/index.ts
@@ -1,10 +1,14 @@
 import { createClient } from '@supabase/supabase-js';
+import { getRequiredEnv } from '@pat87creator/config/env';
+import { log } from '@pat87creator/logger';
 
 type JobStatus = 'queued' | 'processing' | 'completed' | 'failed';
 
 type Env = {
   NEXT_PUBLIC_SUPABASE_URL?: string;
   SUPABASE_SERVICE_ROLE_KEY?: string;
+  STRIPE_SECRET_KEY?: string;
+  STRIPE_WEBHOOK_SECRET?: string;
   ADMIN_SECRET?: string;
   VIDEO_JOB_QUEUE?: Queue;
 };
@@ -49,27 +53,6 @@ function json(data: JsonRecord, status = 200): Response {
   });
 }
 
-function log(level: 'info' | 'warn' | 'error', message: string, context: JsonRecord = {}): void {
-  const record = {
-    level,
-    message,
-    ...context
-  };
-
-  const serialized = JSON.stringify(record);
-  if (level === 'error') {
-    console.error(serialized);
-    return;
-  }
-
-  if (level === 'warn') {
-    console.warn(serialized);
-    return;
-  }
-
-  console.log(serialized);
-}
-
 function parsePositiveInt(value: string | null, fallback: number): number {
   if (!value) {
     return fallback;
@@ -92,11 +75,10 @@ function parseStatus(value: string | null): JobStatus | null {
 }
 
 function createServiceClient(env: Env) {
-  if (!env.NEXT_PUBLIC_SUPABASE_URL || !env.SUPABASE_SERVICE_ROLE_KEY) {
-    throw new Error('Missing Supabase service configuration');
-  }
+  const supabaseUrl = env.NEXT_PUBLIC_SUPABASE_URL ?? getRequiredEnv('NEXT_PUBLIC_SUPABASE_URL');
+  const serviceRoleKey = env.SUPABASE_SERVICE_ROLE_KEY ?? getRequiredEnv('SUPABASE_SERVICE_ROLE_KEY');
 
-  return createClient(env.NEXT_PUBLIC_SUPABASE_URL, env.SUPABASE_SERVICE_ROLE_KEY, {
+  return createClient(supabaseUrl, serviceRoleKey, {
     auth: {
       persistSession: false,
       autoRefreshToken: false
@@ -110,7 +92,7 @@ function authorizeAdmin(request: Request, env: Env): Response | null {
 
   if (!secret || !received || received !== secret) {
     log('warn', 'Unauthorized admin access attempt', {
-      path: new URL(request.url).pathname
+      route: new URL(request.url).pathname
     });
     return json({ error: 'Unauthorized' }, 401);
   }
@@ -158,16 +140,11 @@ async function handleAdminJobs(request: Request, env: Env): Promise<Response> {
   const { data, count, error } = await query.returns<AdminJobRow[]>();
 
   if (error) {
-    log('error', 'Failed to fetch admin jobs', { error: error.message });
-    return json({ error: 'Failed to fetch jobs' }, 500);
+    log('error', 'Failed to fetch admin jobs', { route: '/api/admin/jobs', error: error.message });
+    return json({ error: 'internal_server_error' }, 500);
   }
 
-  return json({
-    total: count ?? 0,
-    page,
-    limit,
-    data: data ?? []
-  });
+  return json({ total: count ?? 0, page, limit, data: data ?? [] });
 }
 
 async function handleAdminMetrics(request: Request, env: Env): Promise<Response> {
@@ -180,8 +157,8 @@ async function handleAdminMetrics(request: Request, env: Env): Promise<Response>
   const { data, error } = await client.from('admin_job_metrics').select('*').single<MetricsRow>();
 
   if (error) {
-    log('error', 'Failed to fetch admin metrics', { error: error.message });
-    return json({ error: 'Failed to fetch metrics' }, 500);
+    log('error', 'Failed to fetch admin metrics', { route: '/api/admin/metrics', error: error.message });
+    return json({ error: 'internal_server_error' }, 500);
   }
 
   return json({
@@ -200,48 +177,49 @@ async function handleAdminMetrics(request: Request, env: Env): Promise<Response>
 }
 
 async function handleHealth(env: Env): Promise<Response> {
-  if (!env.NEXT_PUBLIC_SUPABASE_URL || !env.SUPABASE_SERVICE_ROLE_KEY || !env.ADMIN_SECRET) {
-    return json({ status: 'error', error: 'Missing required environment variables' }, 500);
+  const db = Boolean(env.NEXT_PUBLIC_SUPABASE_URL && env.SUPABASE_SERVICE_ROLE_KEY);
+  const queue = Boolean(env.VIDEO_JOB_QUEUE);
+  const stripe = Boolean(env.STRIPE_SECRET_KEY && env.STRIPE_WEBHOOK_SECRET);
+
+  if (!db || !queue || !stripe || !env.ADMIN_SECRET) {
+    return json({ status: 'error', db, queue, stripe }, 500);
   }
 
-  if (!env.VIDEO_JOB_QUEUE) {
-    return json({ status: 'error', error: 'Queue binding not configured' }, 500);
+  const client = createServiceClient(env);
+  const { error } = await client.from('jobs').select('id').limit(1);
+
+  if (error) {
+    log('error', 'Health check database query failed', { route: '/api/health', error: error.message });
+    return json({ status: 'error', db: false, queue, stripe }, 500);
   }
 
-  try {
-    const client = createServiceClient(env);
-    const { error } = await client.from('jobs').select('id').limit(1);
-
-    if (error) {
-      log('error', 'Health check database query failed', { error: error.message });
-      return json({ status: 'error', error: 'Database unavailable' }, 500);
-    }
-
-    return json({ status: 'ok' });
-  } catch (error) {
-    log('error', 'Health check failed', {
-      error: error instanceof Error ? error.message : 'Unknown health error'
-    });
-    return json({ status: 'error', error: 'Health check failure' }, 500);
-  }
+  return json({ status: 'ok', db: true, queue: true, stripe: true });
 }
 
 export default {
   async fetch(request: Request, env: Env): Promise<Response> {
-    const { pathname } = new URL(request.url);
+    try {
+      const { pathname } = new URL(request.url);
 
-    if (request.method === 'GET' && pathname === '/api/admin/jobs') {
-      return handleAdminJobs(request, env);
+      if (request.method === 'GET' && pathname === '/api/admin/jobs') {
+        return await handleAdminJobs(request, env);
+      }
+
+      if (request.method === 'GET' && pathname === '/api/admin/metrics') {
+        return await handleAdminMetrics(request, env);
+      }
+
+      if (request.method === 'GET' && pathname === '/api/health') {
+        return await handleHealth(env);
+      }
+
+      return json({ error: 'Not found' }, 404);
+    } catch (error) {
+      log('error', 'Unhandled worker-api error', {
+        route: new URL(request.url).pathname,
+        error: error instanceof Error ? error.message : 'unknown_error'
+      });
+      return json({ error: 'internal_server_error' }, 500);
     }
-
-    if (request.method === 'GET' && pathname === '/api/admin/metrics') {
-      return handleAdminMetrics(request, env);
-    }
-
-    if (request.method === 'GET' && pathname === '/api/health') {
-      return handleHealth(env);
-    }
-
-    return json({ error: 'Not found' }, 404);
   }
 } satisfies ExportedHandler<Env>;

--- a/apps/worker-consumer/package.json
+++ b/apps/worker-consumer/package.json
@@ -7,5 +7,8 @@
   },
   "devDependencies": {
     "wrangler": "3.72.0"
+  },
+  "dependencies": {
+    "@pat87creator/logger": "0.1.0"
   }
 }

--- a/apps/worker-consumer/src/index.ts
+++ b/apps/worker-consumer/src/index.ts
@@ -1,4 +1,5 @@
 import { createClient } from '@supabase/supabase-js';
+import { log } from '@pat87creator/logger';
 
 type JobStatus = 'queued' | 'processing' | 'completed' | 'failed';
 
@@ -46,6 +47,14 @@ const PROCESSING_TIMEOUT_MS = 5 * 60 * 1000;
 const DEFAULT_ARTIFACT_BUCKET = 'videos';
 const COMPUTE_COST_PER_SECOND_USD = 0.0004;
 const CREDIT_PRICE_USD = 0.01;
+
+if ('addEventListener' in globalThis) {
+  globalThis.addEventListener('unhandledrejection', (event) => {
+    log('error', 'Unhandled promise rejection in worker-consumer', {
+      reason: event.reason instanceof Error ? event.reason.message : 'unknown_reason'
+    });
+  });
+}
 
 function createServiceClient(env: Env) {
   return createClient(env.NEXT_PUBLIC_SUPABASE_URL, env.SUPABASE_SERVICE_ROLE_KEY, {
@@ -224,7 +233,7 @@ async function finalizeJobEconomics(env: Env, jobId: string, executionDurationMs
   }
 
   const result = (Array.isArray(data) ? data[0] : data) as FinalizeEconomicsRow | null;
-  console.log('Job economics finalized', {
+  log('info', 'Job economics finalized', {
     job_id: jobId,
     execution_duration_ms: executionDurationMs,
     total_cost_usd: result?.total_cost_usd ?? null,
@@ -247,12 +256,12 @@ async function processMessage(message: Message<JobQueueMessage>, env: Env): Prom
   const job = await fetchJob(env, body.job_id);
 
   if (!job) {
-    console.error('Job not found for queued message', { job_id: body.job_id, transition_reason: 'missing_job' });
+    log('error', 'Job not found for queued message', { job_id: body.job_id, transition_reason: 'missing_job' });
     return;
   }
 
   if (job.status === 'completed') {
-    console.log('Skipping already completed job', {
+    log('info', 'Skipping already completed job', {
       job_id: body.job_id,
       processing_token: job.processing_token,
       attempt_count: job.attempt_count,
@@ -264,7 +273,7 @@ async function processMessage(message: Message<JobQueueMessage>, env: Env): Prom
   }
 
   if (job.status === 'failed' && job.attempt_count >= MAX_RETRIES) {
-    console.log('Skipping dead-lettered job', {
+    log('info', 'Skipping dead-lettered job', {
       job_id: body.job_id,
       processing_token: job.processing_token,
       attempt_count: job.attempt_count,
@@ -276,7 +285,7 @@ async function processMessage(message: Message<JobQueueMessage>, env: Env): Prom
   }
 
   if (job.status === 'processing' && !isLockExpired(job.locked_at)) {
-    console.log('Skipping currently locked processing job', {
+    log('info', 'Skipping currently locked processing job', {
       job_id: body.job_id,
       processing_token: job.processing_token,
       attempt_count: job.attempt_count,
@@ -296,7 +305,7 @@ async function processMessage(message: Message<JobQueueMessage>, env: Env): Prom
   try {
     started = await startProcessing(env, job);
 
-    console.log('Transitioning job to processing', {
+    log('info', 'Transitioning job to processing', {
       job_id: body.job_id,
       processing_token: started.processingToken,
       attempt_count: started.attemptCount,
@@ -310,7 +319,7 @@ async function processMessage(message: Message<JobQueueMessage>, env: Env): Prom
     }
 
     if (refreshedJob.status === 'completed') {
-      console.log('Skipping heavy processing for completed job', {
+      log('info', 'Skipping heavy processing for completed job', {
         job_id: body.job_id,
         processing_token: started.processingToken,
         attempt_count: started.attemptCount,
@@ -321,7 +330,7 @@ async function processMessage(message: Message<JobQueueMessage>, env: Env): Prom
     }
 
     if (refreshedJob.result_payload) {
-      console.log('Result payload already exists, finalizing job without heavy processing', {
+      log('info', 'Result payload already exists, finalizing job without heavy processing', {
         job_id: body.job_id,
         processing_token: started.processingToken,
         attempt_count: started.attemptCount,
@@ -350,7 +359,7 @@ async function processMessage(message: Message<JobQueueMessage>, env: Env): Prom
         source: 'existing_artifact'
       };
 
-      console.log('Artifact already exists, bypassing heavy processing', {
+      log('info', 'Artifact already exists, bypassing heavy processing', {
         job_id: body.job_id,
         processing_token: started.processingToken,
         attempt_count: started.attemptCount,
@@ -390,7 +399,7 @@ async function processMessage(message: Message<JobQueueMessage>, env: Env): Prom
     );
     await finalizeJobEconomics(env, body.job_id, durationMs);
 
-    console.log('Transitioning job to completed', {
+    log('info', 'Transitioning job to completed', {
       job_id: body.job_id,
       processing_token: started.processingToken,
       attempt_count: started.attemptCount,
@@ -407,7 +416,7 @@ async function processMessage(message: Message<JobQueueMessage>, env: Env): Prom
 
     const nextStatus: 'queued' | 'failed' = started.attemptCount < MAX_RETRIES ? 'queued' : 'failed';
 
-    console.error('Video job processing failed', {
+    log('error', 'Video job processing failed', {
       job_id: body.job_id,
       processing_token: started.processingToken,
       attempt_count: started.attemptCount,
@@ -416,22 +425,38 @@ async function processMessage(message: Message<JobQueueMessage>, env: Env): Prom
       error: errorMessage
     });
 
-    await updateFinalStatus(
-      env,
-      body.job_id,
-      nextStatus,
-      started.attemptCount,
-      started.processingToken,
-      started.processingStartedAt,
-      nextStatus === 'failed' ? errorMessage : undefined
-    );
+    try {
+      await updateFinalStatus(
+        env,
+        body.job_id,
+        nextStatus,
+        started.attemptCount,
+        started.processingToken,
+        started.processingStartedAt,
+        nextStatus === 'failed' ? errorMessage : undefined
+      );
+
+      if (nextStatus === 'failed') {
+        log('warn', 'Job transitioned to dead-letter state', {
+          job_id: body.job_id,
+          attempt_count: started.attemptCount,
+          transition: 'processing -> failed'
+        });
+      }
+    } catch (finalizeError) {
+      log('error', 'Failed to finalize job status after processing error', {
+        job_id: body.job_id,
+        error: finalizeError instanceof Error ? finalizeError.message : 'unknown_finalize_error'
+      });
+      throw finalizeError;
+    }
   }
 }
 
 export default {
   async queue(batch: MessageBatch<JobQueueMessage>, env: Env): Promise<void> {
     if (!env.NEXT_PUBLIC_SUPABASE_URL || !env.SUPABASE_SERVICE_ROLE_KEY) {
-      console.error('Missing required worker environment variables');
+      log('error', 'Missing required worker environment variables');
       return;
     }
 
@@ -440,7 +465,7 @@ export default {
         await processMessage(message, env);
         message.ack();
       } catch (error) {
-        console.error('Unhandled queue message error', {
+        log('error', 'Unhandled queue message error', {
           message: error instanceof Error ? error.message : 'Unknown error'
         });
         message.retry();

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,8 @@
       "name": "@pat87creator/web",
       "version": "0.1.0",
       "dependencies": {
+        "@pat87creator/config": "0.1.0",
+        "@pat87creator/logger": "0.1.0",
         "next": "14.2.12",
         "react": "18.3.1",
         "react-dom": "18.3.1",
@@ -35,6 +37,10 @@
     "apps/worker-api": {
       "name": "@pat87creator/worker-api",
       "version": "0.1.0",
+      "dependencies": {
+        "@pat87creator/config": "0.1.0",
+        "@pat87creator/logger": "0.1.0"
+      },
       "devDependencies": {
         "wrangler": "3.72.0"
       }
@@ -42,6 +48,9 @@
     "apps/worker-consumer": {
       "name": "@pat87creator/worker-consumer",
       "version": "0.1.0",
+      "dependencies": {
+        "@pat87creator/logger": "0.1.0"
+      },
       "devDependencies": {
         "wrangler": "3.72.0"
       }
@@ -753,8 +762,16 @@
         "node": ">= 10"
       }
     },
+    "node_modules/@pat87creator/config": {
+      "resolved": "packages/config",
+      "link": true
+    },
     "node_modules/@pat87creator/db": {
       "resolved": "packages/db",
+      "link": true
+    },
+    "node_modules/@pat87creator/logger": {
+      "resolved": "packages/logger",
       "link": true
     },
     "node_modules/@pat87creator/shared": {
@@ -2305,8 +2322,16 @@
         "url": "https://github.com/sponsors/colinhacks"
       }
     },
+    "packages/config": {
+      "name": "@pat87creator/config",
+      "version": "0.1.0"
+    },
     "packages/db": {
       "name": "@pat87creator/db",
+      "version": "0.1.0"
+    },
+    "packages/logger": {
+      "name": "@pat87creator/logger",
       "version": "0.1.0"
     },
     "packages/shared": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,9 @@
     "dev:web": "npm run dev --workspace @pat87creator/web",
     "build:web": "npm run build --workspace @pat87creator/web",
     "build:worker-api": "npm run build --workspace @pat87creator/worker-api",
-    "build:worker-consumer": "npm run build --workspace @pat87creator/worker-consumer"
+    "build:worker-consumer": "npm run build --workspace @pat87creator/worker-consumer",
+    "validate:env": "node packages/config/validate.js",
+    "typecheck": "npm run typecheck --workspace @pat87creator/web"
   },
   "dependencies": {
     "@supabase/supabase-js": "^2.98.0"

--- a/packages/config/env.ts
+++ b/packages/config/env.ts
@@ -1,0 +1,42 @@
+export type RequiredEnvKey =
+  | 'NEXT_PUBLIC_SUPABASE_URL'
+  | 'NEXT_PUBLIC_SUPABASE_ANON_KEY'
+  | 'SUPABASE_SERVICE_ROLE_KEY'
+  | 'STRIPE_SECRET_KEY'
+  | 'STRIPE_WEBHOOK_SECRET'
+  | 'ADMIN_SECRET'
+  | 'CLOUDFLARE_QUEUE';
+
+const SECRET_HINTS = ['SECRET', 'TOKEN', 'KEY', 'PASSWORD', 'WEBHOOK'];
+
+function isBlank(value: string | undefined): boolean {
+  return typeof value !== 'string' || value.trim().length === 0;
+}
+
+export function getRequiredEnv(key: RequiredEnvKey, env: Record<string, string | undefined> = process.env): string {
+  const value = env[key];
+  if (isBlank(value)) {
+    throw new Error(`[env] Missing required environment variable: ${key}`);
+  }
+
+  return value as string;
+}
+
+export function validateRequiredEnv(keys: readonly RequiredEnvKey[], env: Record<string, string | undefined> = process.env): void {
+  const missing = keys.filter((key) => isBlank(env[key]));
+  if (missing.length > 0) {
+    throw new Error(`[env] Missing required environment variables: ${missing.join(', ')}`);
+  }
+}
+
+export function redactEnvValue(key: string, value: string | undefined): string {
+  if (!value) {
+    return '[missing]';
+  }
+
+  if (SECRET_HINTS.some((hint) => key.toUpperCase().includes(hint))) {
+    return '[redacted]';
+  }
+
+  return value as string;
+}

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@pat87creator/config",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    "./env": "./env.ts"
+  }
+}

--- a/packages/config/validate.js
+++ b/packages/config/validate.js
@@ -1,0 +1,21 @@
+const required = [
+  'NEXT_PUBLIC_SUPABASE_URL',
+  'NEXT_PUBLIC_SUPABASE_ANON_KEY',
+  'SUPABASE_SERVICE_ROLE_KEY',
+  'STRIPE_SECRET_KEY',
+  'STRIPE_WEBHOOK_SECRET',
+  'ADMIN_SECRET',
+  'CLOUDFLARE_QUEUE'
+];
+
+const missing = required.filter((key) => {
+  const value = process.env[key];
+  return typeof value !== 'string' || value.trim().length === 0;
+});
+
+if (missing.length > 0) {
+  console.error(`[validate:env] Missing required environment variables: ${missing.join(', ')}`);
+  process.exit(1);
+}
+
+console.log('[validate:env] OK');

--- a/packages/logger/index.ts
+++ b/packages/logger/index.ts
@@ -1,0 +1,56 @@
+export type LogLevel = 'info' | 'warn' | 'error' | 'debug';
+
+type LogContext = Record<string, unknown>;
+
+const SECRET_KEYS = ['secret', 'token', 'password', 'authorization', 'key', 'signature'];
+
+function isProduction(): boolean {
+  return process.env.NODE_ENV === 'production';
+}
+
+function sanitize(value: unknown): LogContext | unknown {
+  if (Array.isArray(value)) {
+    return value.map(sanitize);
+  }
+
+  if (value && typeof value === 'object') {
+    const entries = Object.entries(value as Record<string, unknown>).map(([key, entry]) => {
+      if (SECRET_KEYS.some((secretKey) => key.toLowerCase().includes(secretKey))) {
+        return [key, '[redacted]'];
+      }
+
+      return [key, sanitize(entry)];
+    });
+
+    return Object.fromEntries(entries);
+  }
+
+  return value;
+}
+
+export function log(level: LogLevel, message: string, context: LogContext = {}): void {
+  if (level === 'debug' && isProduction()) {
+    return;
+  }
+
+  const safeContext = sanitize(context) as LogContext;
+  const entry = {
+    timestamp: new Date().toISOString(),
+    level,
+    message,
+    ...safeContext
+  };
+
+  const serialized = JSON.stringify(entry);
+  if (level === 'error') {
+    console.error(serialized);
+    return;
+  }
+
+  if (level === 'warn') {
+    console.warn(serialized);
+    return;
+  }
+
+  console.log(serialized);
+}

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@pat87creator/logger",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": "./index.ts"
+  }
+}


### PR DESCRIPTION
### Motivation
- Harden the codebase for production by failing fast on missing environment variables and eliminating silent runtime misconfiguration.
- Prevent stack-trace leakage and excessive debug output in production while preserving developer diagnostics in non-prod.
- Centralize logging and remove ad-hoc console outputs to ensure secret-safe, structured logs with request/route context.
- Improve operational safety for Stripe webhooks, queue consumers, and the health endpoint so critical failures are visible and handled deterministically.

### Description
- Added a small config package `@pat87creator/config` with `getRequiredEnv`, `validateRequiredEnv`, and `redactEnvValue` for centralized, fail-fast environment validation, and a build-time script `packages/config/validate.js` wired to `npm run validate:env`.
- Introduced a structured logging package `@pat87creator/logger` providing `log(level, message, context)`, timestamping, secret redaction, and production `debug` suppression, and replaced ad-hoc `console.*` calls in API routes, worker consumer, and worker API.
- Added runtime guard and safe API wrapper (`apps/web/lib/runtime.ts`, `apps/web/app/api/_lib/safeHandler.ts`) and a global frontend error boundary (`apps/web/app/error.tsx`) so unhandled errors return `{"error":"internal_server_error"}` in APIs and do not expose stacks in production.
- Hardened endpoints and workers: web API routes now use `getRequiredEnv(...)` and `withSafeApiHandler`; Stripe webhook enforces content-type and signature verification and logs failures safely; worker API `/api/health` validates DB/queue/Stripe readiness and returns 500 on critical failures; worker consumer catches unhandled promise rejections, finalizes job state reliably, logs dead-letter transitions, and uses the structured logger.

### Testing
- `npm run typecheck` (workspace web) completed successfully after the changes and import/path fixes.
- `npm run validate:env` failed when required env vars were absent (expected fail-fast behavior) and succeeded when the required env vars were provided.
- Full build: `NEXT_PUBLIC_SUPABASE_URL=... NEXT_PUBLIC_SUPABASE_ANON_KEY=... SUPABASE_SERVICE_ROLE_KEY=... STRIPE_SECRET_KEY=... STRIPE_WEBHOOK_SECRET=... NEXT_PUBLIC_APP_URL=... ADMIN_SECRET=... CLOUDFLARE_QUEUE=... npm run build` succeeded, and worker dry-run builds (`wrangler --dry-run`) completed during the build step.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a6c0af9b78833191f9893c46abff66)