### PR TITLE
Phase 22 follow-up: add centralized alert dispatcher and wire critical failure alerts

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,3 +12,7 @@ API_ENV=development
 
 # Shared
 APP_ENV=development
+
+# Alerts
+ALERT_SLACK_WEBHOOK_URL=
+ALERT_EMAIL_TO=

--- a/apps/web/app/api/stripe/webhook/route.ts
+++ b/apps/web/app/api/stripe/webhook/route.ts
@@ -1,4 +1,5 @@
 import { createClient } from '@supabase/supabase-js';
+import { dispatchAlert } from '@pat87creator/alerts/dispatcher';
 import { getRequiredEnv } from '@pat87creator/config/env';
 import { log } from '@pat87creator/logger';
 import { withSafeApiHandler } from '../../_lib/safeHandler';
@@ -8,6 +9,9 @@ const stripeSecretKey = getRequiredEnv('STRIPE_SECRET_KEY');
 const stripeWebhookSecret = getRequiredEnv('STRIPE_WEBHOOK_SECRET');
 const supabaseUrl = getRequiredEnv('NEXT_PUBLIC_SUPABASE_URL');
 const supabaseServiceRoleKey = getRequiredEnv('SUPABASE_SERVICE_ROLE_KEY');
+
+const alertSlackWebhookUrl = process.env.ALERT_SLACK_WEBHOOK_URL;
+const alertEmailTo = process.env.ALERT_EMAIL_TO;
 
 const stripe = new Stripe(stripeSecretKey, {
   apiVersion: '2024-06-20'
@@ -21,12 +25,40 @@ export const POST = withSafeApiHandler('/api/stripe/webhook', async (request: Re
   const contentType = request.headers.get('content-type') ?? '';
   if (!contentType.toLowerCase().startsWith('application/json')) {
     log('warn', 'Rejected Stripe webhook invalid content-type', { route: '/api/stripe/webhook', content_type: contentType });
+    await dispatchAlert(
+      {
+        severity: 'warning',
+        service: 'stripe',
+        event: 'webhook_failure',
+        message: 'Stripe Webhook Verification Failure',
+        metadata: {
+          route: '/api/stripe/webhook',
+          reason: 'invalid_content_type',
+          timestamp: new Date().toISOString()
+        }
+      },
+      { ALERT_SLACK_WEBHOOK_URL: alertSlackWebhookUrl, ALERT_EMAIL_TO: alertEmailTo }
+    );
     return new Response('Invalid content-type', { status: 415 });
   }
 
   const signature = request.headers.get('stripe-signature');
   if (!signature) {
     log('warn', 'Rejected Stripe webhook missing signature', { route: '/api/stripe/webhook' });
+    await dispatchAlert(
+      {
+        severity: 'warning',
+        service: 'stripe',
+        event: 'webhook_failure',
+        message: 'Stripe Webhook Verification Failure',
+        metadata: {
+          route: '/api/stripe/webhook',
+          reason: 'missing_signature',
+          timestamp: new Date().toISOString()
+        }
+      },
+      { ALERT_SLACK_WEBHOOK_URL: alertSlackWebhookUrl, ALERT_EMAIL_TO: alertEmailTo }
+    );
     return new Response('Missing Stripe signature header', { status: 400 });
   }
 
@@ -37,6 +69,21 @@ export const POST = withSafeApiHandler('/api/stripe/webhook', async (request: Re
     event = stripe.webhooks.constructEvent(rawBody, signature, stripeWebhookSecret);
   } catch {
     log('warn', 'Stripe webhook signature verification failed', { route: '/api/stripe/webhook' });
+    await dispatchAlert(
+      {
+        severity: 'warning',
+        service: 'stripe',
+        event: 'webhook_failure',
+        message: 'Stripe Webhook Verification Failure',
+        metadata: {
+          route: '/api/stripe/webhook',
+          reason: 'signature_verification_failed',
+          source_ip: request.headers.get('x-forwarded-for') ?? request.headers.get('cf-connecting-ip') ?? 'unknown',
+          timestamp: new Date().toISOString()
+        }
+      },
+      { ALERT_SLACK_WEBHOOK_URL: alertSlackWebhookUrl, ALERT_EMAIL_TO: alertEmailTo }
+    );
     return new Response('Invalid Stripe signature', { status: 400 });
   }
 
@@ -79,6 +126,21 @@ export const POST = withSafeApiHandler('/api/stripe/webhook', async (request: Re
 
   if (error) {
     log('warn', 'Stripe webhook process_stripe_payment RPC failed', { route: '/api/stripe/webhook', provider_reference: event.id });
+    await dispatchAlert(
+      {
+        severity: 'warning',
+        service: 'stripe',
+        event: 'webhook_failure',
+        message: 'Stripe Webhook Handler Failure',
+        metadata: {
+          route: '/api/stripe/webhook',
+          event_id: event.id,
+          error_message: error.message,
+          timestamp: new Date().toISOString()
+        }
+      },
+      { ALERT_SLACK_WEBHOOK_URL: alertSlackWebhookUrl, ALERT_EMAIL_TO: alertEmailTo }
+    );
   }
 
   return new Response('Webhook handled', { status: 200 });

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -14,7 +14,8 @@
     "react-dom": "18.3.1",
     "stripe": "^16.10.0",
     "@pat87creator/config": "0.1.0",
-    "@pat87creator/logger": "0.1.0"
+    "@pat87creator/logger": "0.1.0",
+    "@pat87creator/alerts": "0.1.0"
   },
   "devDependencies": {
     "typescript": "5.5.4",

--- a/apps/worker-api/package.json
+++ b/apps/worker-api/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@pat87creator/config": "0.1.0",
-    "@pat87creator/logger": "0.1.0"
+    "@pat87creator/logger": "0.1.0",
+    "@pat87creator/alerts": "0.1.0"
   }
 }

--- a/apps/worker-api/src/index.ts
+++ b/apps/worker-api/src/index.ts
@@ -1,4 +1,5 @@
 import { createClient } from '@supabase/supabase-js';
+import { dispatchAlert } from '@pat87creator/alerts/dispatcher';
 import { getRequiredEnv } from '@pat87creator/config/env';
 import { log } from '@pat87creator/logger';
 
@@ -11,6 +12,8 @@ type Env = {
   STRIPE_WEBHOOK_SECRET?: string;
   ADMIN_SECRET?: string;
   VIDEO_JOB_QUEUE?: Queue;
+  ALERT_SLACK_WEBHOOK_URL?: string;
+  ALERT_EMAIL_TO?: string;
 };
 
 type JsonRecord = Record<string, unknown>;
@@ -182,6 +185,30 @@ async function handleHealth(env: Env): Promise<Response> {
   const stripe = Boolean(env.STRIPE_SECRET_KEY && env.STRIPE_WEBHOOK_SECRET);
 
   if (!db || !queue || !stripe || !env.ADMIN_SECRET) {
+    const failingComponents = [
+      !db ? 'db_config' : null,
+      !queue ? 'queue_binding' : null,
+      !stripe ? 'stripe_config' : null,
+      !env.ADMIN_SECRET ? 'admin_secret' : null
+    ].filter(Boolean);
+
+    await dispatchAlert(
+      {
+        severity: 'critical',
+        service: 'system',
+        event: 'health_failure',
+        message: 'System Health Failure',
+        metadata: {
+          route: '/api/health',
+          failing_components: failingComponents.join(','),
+          db,
+          queue,
+          stripe
+        }
+      },
+      env
+    );
+
     return json({ status: 'error', db, queue, stripe }, 500);
   }
 
@@ -190,6 +217,22 @@ async function handleHealth(env: Env): Promise<Response> {
 
   if (error) {
     log('error', 'Health check database query failed', { route: '/api/health', error: error.message });
+
+    await dispatchAlert(
+      {
+        severity: 'critical',
+        service: 'system',
+        event: 'health_failure',
+        message: 'System Health Failure',
+        metadata: {
+          route: '/api/health',
+          failing_component: 'db_query',
+          error_message: error.message
+        }
+      },
+      env
+    );
+
     return json({ status: 'error', db: false, queue, stripe }, 500);
   }
 
@@ -215,10 +258,27 @@ export default {
 
       return json({ error: 'Not found' }, 404);
     } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : 'unknown_error';
+
       log('error', 'Unhandled worker-api error', {
         route: new URL(request.url).pathname,
-        error: error instanceof Error ? error.message : 'unknown_error'
+        error: errorMessage
       });
+
+      await dispatchAlert(
+        {
+          severity: 'warning',
+          service: 'api',
+          event: 'worker_error',
+          message: 'Worker API Unhandled Failure',
+          metadata: {
+            route: new URL(request.url).pathname,
+            error_message: errorMessage
+          }
+        },
+        env
+      );
+
       return json({ error: 'internal_server_error' }, 500);
     }
   }

--- a/apps/worker-consumer/package.json
+++ b/apps/worker-consumer/package.json
@@ -9,6 +9,7 @@
     "wrangler": "3.72.0"
   },
   "dependencies": {
-    "@pat87creator/logger": "0.1.0"
+    "@pat87creator/logger": "0.1.0",
+    "@pat87creator/alerts": "0.1.0"
   }
 }

--- a/apps/worker-consumer/src/index.ts
+++ b/apps/worker-consumer/src/index.ts
@@ -1,4 +1,5 @@
 import { createClient } from '@supabase/supabase-js';
+import { dispatchAlert } from '@pat87creator/alerts/dispatcher';
 import { log } from '@pat87creator/logger';
 
 type JobStatus = 'queued' | 'processing' | 'completed' | 'failed';
@@ -40,6 +41,8 @@ type Env = {
   NEXT_PUBLIC_SUPABASE_URL: string;
   SUPABASE_SERVICE_ROLE_KEY: string;
   SUPABASE_ARTIFACT_BUCKET?: string;
+  ALERT_SLACK_WEBHOOK_URL?: string;
+  ALERT_EMAIL_TO?: string;
 };
 
 const MAX_RETRIES = 3;
@@ -50,8 +53,28 @@ const CREDIT_PRICE_USD = 0.01;
 
 if ('addEventListener' in globalThis) {
   globalThis.addEventListener('unhandledrejection', (event) => {
+    const errorMessage = event.reason instanceof Error ? event.reason.message : 'unknown_reason';
+
     log('error', 'Unhandled promise rejection in worker-consumer', {
-      reason: event.reason instanceof Error ? event.reason.message : 'unknown_reason'
+      reason: errorMessage
+    });
+
+    void dispatchAlert(
+      {
+        severity: 'warning',
+        service: 'worker',
+        event: 'worker_error',
+        message: 'Worker Processing Failure',
+        metadata: {
+          error_message: errorMessage,
+          worker_context: 'worker-consumer:unhandledrejection'
+        }
+      },
+      globalThis as Env
+    ).catch((error) => {
+      log('error', 'Failed to dispatch unhandled rejection alert', {
+        error: error instanceof Error ? error.message : 'unknown_alert_error'
+      });
     });
   });
 }
@@ -240,6 +263,25 @@ async function finalizeJobEconomics(env: Env, jobId: string, executionDurationMs
     revenue_usd: result?.revenue_usd ?? null,
     margin_usd: result?.margin_usd ?? null
   });
+
+  if ((result?.margin_usd ?? 0) < 0) {
+    await dispatchAlert(
+      {
+        severity: 'warning',
+        service: 'worker',
+        event: 'margin_anomaly',
+        message: 'Negative Margin Job Detected',
+        metadata: {
+          job_id: jobId,
+          cost: result?.total_cost_usd ?? null,
+          revenue: result?.revenue_usd ?? null,
+          margin: result?.margin_usd ?? null,
+          source: 'worker-consumer'
+        }
+      },
+      env
+    );
+  }
 }
 
 async function simulateProcessing(): Promise<void> {
@@ -425,6 +467,23 @@ async function processMessage(message: Message<JobQueueMessage>, env: Env): Prom
       error: errorMessage
     });
 
+    await dispatchAlert(
+      {
+        severity: 'warning',
+        service: 'worker',
+        event: 'worker_error',
+        message: 'Worker Processing Failure',
+        metadata: {
+          job_id: body.job_id,
+          user_id: body.user_id,
+          attempt_count: started.attemptCount,
+          error_message: errorMessage,
+          worker_context: 'worker-consumer:processMessage'
+        }
+      },
+      env
+    );
+
     try {
       await updateFinalStatus(
         env,
@@ -442,6 +501,23 @@ async function processMessage(message: Message<JobQueueMessage>, env: Env): Prom
           attempt_count: started.attemptCount,
           transition: 'processing -> failed'
         });
+
+        await dispatchAlert(
+          {
+            severity: 'critical',
+            service: 'worker',
+            event: 'dead_letter',
+            message: 'Dead Letter Job Detected',
+            metadata: {
+              job_id: body.job_id,
+              user_id: body.user_id,
+              attempt_count: started.attemptCount,
+              error_message: errorMessage,
+              source: 'worker-consumer'
+            }
+          },
+          env
+        );
       }
     } catch (finalizeError) {
       log('error', 'Failed to finalize job status after processing error', {

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
       "name": "@pat87creator/web",
       "version": "0.1.0",
       "dependencies": {
+        "@pat87creator/alerts": "0.1.0",
         "@pat87creator/config": "0.1.0",
         "@pat87creator/logger": "0.1.0",
         "next": "14.2.12",
@@ -38,6 +39,7 @@
       "name": "@pat87creator/worker-api",
       "version": "0.1.0",
       "dependencies": {
+        "@pat87creator/alerts": "0.1.0",
         "@pat87creator/config": "0.1.0",
         "@pat87creator/logger": "0.1.0"
       },
@@ -49,6 +51,7 @@
       "name": "@pat87creator/worker-consumer",
       "version": "0.1.0",
       "dependencies": {
+        "@pat87creator/alerts": "0.1.0",
         "@pat87creator/logger": "0.1.0"
       },
       "devDependencies": {
@@ -761,6 +764,10 @@
       "engines": {
         "node": ">= 10"
       }
+    },
+    "node_modules/@pat87creator/alerts": {
+      "resolved": "packages/alerts",
+      "link": true
     },
     "node_modules/@pat87creator/config": {
       "resolved": "packages/config",
@@ -2321,6 +2328,10 @@
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
+    },
+    "packages/alerts": {
+      "name": "@pat87creator/alerts",
+      "version": "0.1.0"
     },
     "packages/config": {
       "name": "@pat87creator/config",

--- a/packages/alerts/dispatcher.ts
+++ b/packages/alerts/dispatcher.ts
@@ -1,0 +1,175 @@
+import { log } from '@pat87creator/logger';
+
+export type AlertSeverity = 'critical' | 'warning';
+export type AlertService = 'worker' | 'api' | 'stripe' | 'system';
+export type AlertEvent =
+  | 'dead_letter'
+  | 'webhook_failure'
+  | 'worker_error'
+  | 'health_failure'
+  | 'margin_anomaly';
+
+export type AlertPayload = {
+  severity: AlertSeverity;
+  service: AlertService;
+  event: AlertEvent;
+  message: string;
+  metadata?: Record<string, unknown>;
+};
+
+export type AlertEnv = {
+  ALERT_SLACK_WEBHOOK_URL?: string;
+  ALERT_EMAIL_TO?: string;
+};
+
+const ALERT_INTERVAL_MS = 60_000;
+const recentAlertTypes = new Map<string, number>();
+const recentFingerprints = new Map<string, number>();
+
+function cleanupRecentAlerts(now: number): void {
+  for (const [key, timestamp] of recentAlertTypes.entries()) {
+    if (now - timestamp > ALERT_INTERVAL_MS) {
+      recentAlertTypes.delete(key);
+    }
+  }
+
+  for (const [key, timestamp] of recentFingerprints.entries()) {
+    if (now - timestamp > ALERT_INTERVAL_MS) {
+      recentFingerprints.delete(key);
+    }
+  }
+}
+
+function sanitizeMetadata(metadata: Record<string, unknown>): Record<string, unknown> {
+  const entries = Object.entries(metadata)
+    .filter(([key]) => {
+      const lowered = key.toLowerCase();
+      return !(
+        lowered.includes('secret') ||
+        lowered.includes('token') ||
+        lowered.includes('authorization') ||
+        lowered.includes('header') ||
+        lowered.includes('cookie') ||
+        lowered.includes('password')
+      );
+    })
+    .map(([key, value]) => [key, value ?? null]);
+
+  return Object.fromEntries(entries);
+}
+
+function fingerprintFor(alert: AlertPayload): string {
+  return JSON.stringify({
+    severity: alert.severity,
+    service: alert.service,
+    event: alert.event,
+    message: alert.message,
+    metadata: sanitizeMetadata(alert.metadata ?? {})
+  });
+}
+
+function shouldRateLimit(alert: AlertPayload, now: number): { limited: boolean; reason: 'type' | 'duplicate' | null } {
+  cleanupRecentAlerts(now);
+
+  const typeKey = `${alert.service}:${alert.event}:${alert.severity}`;
+  if (recentAlertTypes.has(typeKey)) {
+    return { limited: true, reason: 'type' };
+  }
+
+  const fingerprint = fingerprintFor(alert);
+  if (recentFingerprints.has(fingerprint)) {
+    return { limited: true, reason: 'duplicate' };
+  }
+
+  recentAlertTypes.set(typeKey, now);
+  recentFingerprints.set(fingerprint, now);
+  return { limited: false, reason: null };
+}
+
+function buildSlackText(alert: AlertPayload): string {
+  const emoji = alert.severity === 'critical' ? '🚨' : '⚠️';
+  const metadata = sanitizeMetadata(alert.metadata ?? {});
+  const metadataLines = Object.entries(metadata).map(([key, value]) => `• *${key}*: ${String(value)}`);
+
+  return [
+    `${emoji} *${alert.message}*`,
+    `Service: ${alert.service}`,
+    `Event: ${alert.event}`,
+    ...metadataLines
+  ].join('\n');
+}
+
+async function sendSlackAlert(alert: AlertPayload, webhookUrl: string): Promise<void> {
+  const response = await fetch(webhookUrl, {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json'
+    },
+    body: JSON.stringify({
+      text: buildSlackText(alert)
+    })
+  });
+
+  if (!response.ok) {
+    throw new Error(`Slack webhook failed with status ${response.status}`);
+  }
+}
+
+async function sendEmailAlert(alert: AlertPayload, emailTo: string): Promise<void> {
+  log('warn', 'Email alert channel configured but not implemented; logging fallback used', {
+    alert_event: alert.event,
+    alert_service: alert.service,
+    alert_severity: alert.severity,
+    email_to: emailTo
+  });
+}
+
+export async function dispatchAlert(alert: AlertPayload, env: AlertEnv): Promise<void> {
+  const now = Date.now();
+  const rateLimit = shouldRateLimit(alert, now);
+
+  if (rateLimit.limited) {
+    log('info', 'Alert suppressed by deduplication/rate limiting', {
+      alert_event: alert.event,
+      alert_service: alert.service,
+      alert_severity: alert.severity,
+      suppression_reason: rateLimit.reason
+    });
+    return;
+  }
+
+  const safeMetadata = sanitizeMetadata(alert.metadata ?? {});
+  const safeAlert: AlertPayload = {
+    ...alert,
+    metadata: safeMetadata
+  };
+
+  log('warn', 'Dispatching operational alert', {
+    alert_event: safeAlert.event,
+    alert_service: safeAlert.service,
+    alert_severity: safeAlert.severity,
+    alert_message: safeAlert.message,
+    metadata: safeAlert.metadata
+  });
+
+  const channelPromises: Promise<void>[] = [];
+
+  if (env.ALERT_SLACK_WEBHOOK_URL) {
+    channelPromises.push(sendSlackAlert(safeAlert, env.ALERT_SLACK_WEBHOOK_URL));
+  }
+
+  if (env.ALERT_EMAIL_TO) {
+    channelPromises.push(sendEmailAlert(safeAlert, env.ALERT_EMAIL_TO));
+  }
+
+  if (channelPromises.length === 0) {
+    log('warn', 'No alert channels configured; alert only logged', {
+      alert_event: safeAlert.event,
+      alert_service: safeAlert.service,
+      alert_severity: safeAlert.severity
+    });
+    return;
+  }
+
+  await Promise.all(channelPromises);
+}

--- a/packages/alerts/package.json
+++ b/packages/alerts/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@pat87creator/alerts",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    "./dispatcher": "./dispatcher.ts"
+  }
+}


### PR DESCRIPTION
### Motivation
- Provide a centralized, standardized alerting layer so critical failures (dead-letter jobs, worker crashes, Stripe webhook failures, health check failures, and negative-margin jobs) are visible to operators.
- Prevent alert spam and accidental secrets leakage by implementing deduplication/rate-limiting and metadata sanitization.

### Description
- Added a new package `@pat87creator/alerts` with `packages/alerts/dispatcher.ts` implementing a standardized alert payload, Slack delivery, an email fallback (logging), metadata sanitization, per-type and fingerprint deduplication, and a 1-minute suppression window.
- Wired alert dispatches into the worker consumer (`apps/worker-consumer/src/index.ts`) for unhandled rejections, processing failures, dead-letter transitions, and negative-margin job detection (calls `dispatchAlert`).
- Wired alert dispatches into the worker API (`apps/worker-api/src/index.ts`) for `/api/health` configuration/component failures, DB health-query failures, and unhandled API exceptions.
- Wired Stripe webhook failure alerts into the webhook handler (`apps/web/app/api/stripe/webhook/route.ts`) for invalid content-type, missing signature, signature verification failure, and RPC handler failures, and added alert env vars to `.env.example` plus package dependencies to relevant workspaces.

### Testing
- Ran `npm install` to update workspace lockfile and local links, which completed successfully.
- Built consumer and API workers with `npm run build:worker-consumer` and `npm run build:worker-api`, and both completed the `wrangler --dry-run` builds successfully after the package was added.
- Ran type checks with `npm run typecheck --workspace @pat87creator/web`, which succeeded with no type errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7e3bf1bdc833193eca6b6e092ebe3)