### PR TITLE
feat: admin monitoring API and dashboard (Phase 23 follow-up)

### DIFF
--- a/apps/web/app/admin/monitoring/page.tsx
+++ b/apps/web/app/admin/monitoring/page.tsx
@@ -1,0 +1,29 @@
+import { AdminMonitoringDashboard } from '../../../components/AdminMonitoringDashboard';
+
+type MonitoringPageProps = {
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+};
+
+export default async function MonitoringPage({ searchParams }: MonitoringPageProps) {
+  const params = await searchParams;
+  const provided = params.admin_secret;
+  const providedSecret = Array.isArray(provided) ? provided[0] : provided;
+  const configuredSecret = process.env.ADMIN_SECRET;
+
+  if (!configuredSecret || !providedSecret || providedSecret !== configuredSecret) {
+    return (
+      <main style={{ maxWidth: 900, margin: '3rem auto', padding: '0 1rem' }}>
+        <h1>Unauthorized</h1>
+        <p>Provide a valid admin secret via the admin_secret query parameter.</p>
+      </main>
+    );
+  }
+
+  return (
+    <main style={{ maxWidth: 1100, margin: '2rem auto', padding: '0 1rem' }}>
+      <h1 style={{ marginTop: 0 }}>Admin Monitoring Dashboard</h1>
+      <p style={{ color: '#4b5563' }}>Operational observability for queue, performance, and unit economics.</p>
+      <AdminMonitoringDashboard adminSecret={providedSecret} />
+    </main>
+  );
+}

--- a/apps/web/app/api/admin/monitoring/route.ts
+++ b/apps/web/app/api/admin/monitoring/route.ts
@@ -1,0 +1,197 @@
+import { createClient } from '@supabase/supabase-js';
+import { getRequiredEnv } from '@pat87creator/config/env';
+import { withSafeApiHandler } from '../../_lib/safeHandler';
+
+type JobStatus = 'queued' | 'processing' | 'completed' | 'failed';
+
+type JobRow = {
+  status: JobStatus;
+  attempt_count: number;
+  billed_credits: number;
+  created_at: string;
+  processing_started_at: string | null;
+  processing_completed_at: string | null;
+  execution_duration_ms: number | null;
+  revenue_usd: number | null;
+};
+
+type JobCostRow = {
+  amount_usd: number;
+  created_at: string;
+};
+
+type HealthResponse = {
+  status?: string;
+  db?: boolean;
+  queue?: boolean;
+  stripe?: boolean;
+};
+
+const MAX_DEAD_LETTER_ATTEMPTS = 3;
+const ONE_HOUR_MS = 60 * 60 * 1000;
+const ONE_DAY_MS = 24 * ONE_HOUR_MS;
+
+const supabaseUrl = getRequiredEnv('NEXT_PUBLIC_SUPABASE_URL');
+const serviceRoleKey = getRequiredEnv('SUPABASE_SERVICE_ROLE_KEY');
+
+function percentile(values: number[], p: number): number {
+  if (values.length === 0) {
+    return 0;
+  }
+
+  const sorted = [...values].sort((a, b) => a - b);
+  const index = Math.ceil((p / 100) * sorted.length) - 1;
+  const safeIndex = Math.max(0, Math.min(sorted.length - 1, index));
+
+  return Math.round(sorted[safeIndex]);
+}
+
+function sum(values: number[]): number {
+  return values.reduce((total, value) => total + value, 0);
+}
+
+function toBoolean(value: unknown): boolean {
+  return value === true;
+}
+
+async function fetchSystemHealth(adminSecret: string, request: Request): Promise<{ db: boolean; queue: boolean; stripe: boolean }> {
+  const configuredBaseUrl = process.env.WORKER_API_BASE_URL;
+
+  if (!configuredBaseUrl) {
+    return {
+      db: true,
+      queue: Boolean(process.env.CLOUDFLARE_QUEUE),
+      stripe: Boolean(process.env.STRIPE_SECRET_KEY && process.env.STRIPE_WEBHOOK_SECRET)
+    };
+  }
+
+  try {
+    const url = new URL('/api/health', configuredBaseUrl);
+    const response = await fetch(url.toString(), {
+      method: 'GET',
+      headers: {
+        'x-admin-secret': adminSecret,
+        'x-forwarded-host': request.headers.get('host') ?? ''
+      },
+      cache: 'no-store'
+    });
+
+    if (!response.ok) {
+      return { db: false, queue: false, stripe: false };
+    }
+
+    const payload = (await response.json()) as HealthResponse;
+
+    return {
+      db: toBoolean(payload.db),
+      queue: toBoolean(payload.queue),
+      stripe: toBoolean(payload.stripe)
+    };
+  } catch {
+    return { db: false, queue: false, stripe: false };
+  }
+}
+
+export const GET = withSafeApiHandler('/api/admin/monitoring', async (request: Request) => {
+  const adminSecret = getRequiredEnv('ADMIN_SECRET');
+  const incomingSecret = request.headers.get('x-admin-secret');
+
+  if (!incomingSecret || incomingSecret !== adminSecret) {
+    return Response.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const now = Date.now();
+  const hourAgoIso = new Date(now - ONE_HOUR_MS).toISOString();
+  const dayAgoIso = new Date(now - ONE_DAY_MS).toISOString();
+  const todayStartIso = new Date(new Date().setHours(0, 0, 0, 0)).toISOString();
+
+  const client = createClient(supabaseUrl, serviceRoleKey, {
+    auth: {
+      persistSession: false,
+      autoRefreshToken: false
+    }
+  });
+
+  const jobsQuery = client
+    .from('jobs')
+    .select(
+      'status, attempt_count, billed_credits, created_at, processing_started_at, processing_completed_at, execution_duration_ms, revenue_usd'
+    )
+    .gte('created_at', dayAgoIso);
+
+  const jobCostsQuery = client.from('job_costs').select('amount_usd, created_at').gte('created_at', todayStartIso);
+
+  const [jobsResult, costsResult, health] = await Promise.all([
+    jobsQuery.returns<JobRow[]>(),
+    jobCostsQuery.returns<JobCostRow[]>(),
+    fetchSystemHealth(adminSecret, request)
+  ]);
+
+  if (jobsResult.error) {
+    return Response.json({ error: 'internal_server_error' }, { status: 500 });
+  }
+
+  if (costsResult.error) {
+    return Response.json({ error: 'internal_server_error' }, { status: 500 });
+  }
+
+  const jobs = jobsResult.data ?? [];
+  const costs = costsResult.data ?? [];
+
+  const hourJobs = jobs.filter((job) => new Date(job.created_at).getTime() >= now - ONE_HOUR_MS);
+  const dayJobs = jobs;
+
+  const completedDurations = jobs
+    .map((job) => job.execution_duration_ms ?? null)
+    .filter((value): value is number => typeof value === 'number' && Number.isFinite(value));
+
+  const creditsConsumedLastHour = sum(hourJobs.map((job) => job.billed_credits ?? 0));
+  const revenueLastHour = sum(hourJobs.map((job) => job.revenue_usd ?? 0));
+
+  const hourCostRows = costs.filter((cost) => new Date(cost.created_at).getTime() >= now - ONE_HOUR_MS);
+  const costLastHour = sum(hourCostRows.map((cost) => cost.amount_usd ?? 0));
+
+  const todayCostRows = costs.filter((cost) => new Date(cost.created_at).getTime() >= new Date(todayStartIso).getTime());
+  const costToday = sum(todayCostRows.map((cost) => cost.amount_usd ?? 0));
+
+  const todayJobs = jobs.filter((job) => new Date(job.created_at).getTime() >= new Date(todayStartIso).getTime());
+  const revenueToday = sum(todayJobs.map((job) => job.revenue_usd ?? 0));
+
+  const completedHour = hourJobs.filter((job) => job.status === 'completed').length;
+  const completedDay = dayJobs.filter((job) => job.status === 'completed').length;
+
+  const successRateHour = hourJobs.length > 0 ? completedHour / hourJobs.length : 0;
+  const successRateDay = dayJobs.length > 0 ? completedDay / dayJobs.length : 0;
+
+  const activeJobs = jobs.filter((job) => job.status === 'processing').length;
+  const queuedJobs = jobs.filter((job) => job.status === 'queued').length;
+  const failedJobs = jobs.filter((job) => job.status === 'failed').length;
+  const deadLetterJobs = jobs.filter(
+    (job) => job.status === 'failed' && (job.attempt_count ?? 0) >= MAX_DEAD_LETTER_ATTEMPTS
+  ).length;
+
+  return Response.json({
+    jobs_last_hour: hourJobs.length,
+    jobs_last_24_hours: dayJobs.length,
+    jobs_success_rate: Number(successRateHour.toFixed(4)),
+    jobs_success_rate_24h: Number(successRateDay.toFixed(4)),
+    jobs_failed: failedJobs,
+    dead_letter_count: deadLetterJobs,
+    avg_processing_time_ms: completedDurations.length > 0 ? Math.round(sum(completedDurations) / completedDurations.length) : 0,
+    p95_processing_time_ms: percentile(completedDurations, 95),
+    active_jobs: activeJobs,
+    queue_depth: queuedJobs + activeJobs,
+    jobs_processing: activeJobs,
+    jobs_queued: queuedJobs,
+    jobs_dead_letter: deadLetterJobs,
+    credits_consumed_last_hour: creditsConsumedLastHour,
+    revenue_last_hour_usd: Number(revenueLastHour.toFixed(2)),
+    cost_last_hour_usd: Number(costLastHour.toFixed(2)),
+    margin_last_hour_usd: Number((revenueLastHour - costLastHour).toFixed(2)),
+    revenue_today_usd: Number(revenueToday.toFixed(2)),
+    cost_today_usd: Number(costToday.toFixed(2)),
+    margin_today_usd: Number((revenueToday - costToday).toFixed(2)),
+    system_health: health,
+    refreshed_at: new Date().toISOString()
+  });
+});

--- a/apps/web/components/AdminMonitoringDashboard.tsx
+++ b/apps/web/components/AdminMonitoringDashboard.tsx
@@ -1,0 +1,169 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+type MonitoringResponse = {
+  jobs_last_hour: number;
+  jobs_last_24_hours: number;
+  jobs_success_rate: number;
+  jobs_success_rate_24h: number;
+  jobs_failed: number;
+  dead_letter_count: number;
+  avg_processing_time_ms: number;
+  p95_processing_time_ms: number;
+  active_jobs: number;
+  queue_depth: number;
+  jobs_processing: number;
+  jobs_queued: number;
+  jobs_dead_letter: number;
+  credits_consumed_last_hour: number;
+  revenue_last_hour_usd: number;
+  cost_last_hour_usd: number;
+  margin_last_hour_usd: number;
+  revenue_today_usd: number;
+  cost_today_usd: number;
+  margin_today_usd: number;
+  system_health: {
+    db: boolean;
+    queue: boolean;
+    stripe: boolean;
+  };
+  refreshed_at: string;
+};
+
+function StatCard({ title, value }: { title: string; value: string | number }) {
+  return (
+    <div style={{ border: '1px solid #e5e7eb', borderRadius: 8, padding: 16, backgroundColor: '#fff' }}>
+      <p style={{ margin: 0, fontSize: 12, color: '#6b7280', textTransform: 'uppercase' }}>{title}</p>
+      <p style={{ margin: '8px 0 0', fontSize: 24, fontWeight: 700 }}>{value}</p>
+    </div>
+  );
+}
+
+function HealthBadge({ label, healthy }: { label: string; healthy: boolean }) {
+  return (
+    <span
+      style={{
+        display: 'inline-flex',
+        alignItems: 'center',
+        gap: 6,
+        padding: '6px 12px',
+        borderRadius: 999,
+        backgroundColor: healthy ? '#dcfce7' : '#fee2e2',
+        color: healthy ? '#166534' : '#991b1b',
+        fontWeight: 600,
+        fontSize: 13
+      }}
+    >
+      {label}: {healthy ? 'healthy' : 'unhealthy'}
+    </span>
+  );
+}
+
+export function AdminMonitoringDashboard({ adminSecret }: { adminSecret: string }) {
+  const [data, setData] = useState<MonitoringResponse | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let active = true;
+
+    const fetchMetrics = async () => {
+      const response = await fetch('/api/admin/monitoring', {
+        headers: {
+          'x-admin-secret': adminSecret
+        },
+        cache: 'no-store'
+      });
+
+      if (!response.ok) {
+        throw new Error('Failed to load monitoring metrics');
+      }
+
+      const payload = (await response.json()) as MonitoringResponse;
+
+      if (active) {
+        setData(payload);
+        setError(null);
+      }
+    };
+
+    fetchMetrics().catch((fetchError) => {
+      if (active) {
+        setError(fetchError instanceof Error ? fetchError.message : 'Unknown error');
+      }
+    });
+
+    const interval = window.setInterval(() => {
+      fetchMetrics().catch((fetchError) => {
+        if (active) {
+          setError(fetchError instanceof Error ? fetchError.message : 'Unknown error');
+        }
+      });
+    }, 12_000);
+
+    return () => {
+      active = false;
+      window.clearInterval(interval);
+    };
+  }, [adminSecret]);
+
+  if (error) {
+    return <p style={{ color: '#991b1b' }}>{error}</p>;
+  }
+
+  if (!data) {
+    return <p>Loading monitoring dashboard…</p>;
+  }
+
+  return (
+    <div style={{ display: 'grid', gap: 20 }}>
+      <section style={{ display: 'grid', gap: 12 }}>
+        <h2 style={{ margin: 0 }}>System status</h2>
+        <div style={{ display: 'flex', gap: 10, flexWrap: 'wrap' }}>
+          <HealthBadge label="DB" healthy={data.system_health.db} />
+          <HealthBadge label="Queue" healthy={data.system_health.queue} />
+          <HealthBadge label="Stripe" healthy={data.system_health.stripe} />
+        </div>
+      </section>
+
+      <section style={{ display: 'grid', gap: 12 }}>
+        <h2 style={{ margin: 0 }}>Job processing</h2>
+        <div style={{ display: 'grid', gap: 12, gridTemplateColumns: 'repeat(auto-fill, minmax(180px, 1fr))' }}>
+          <StatCard title="Active jobs" value={data.active_jobs} />
+          <StatCard title="Queued jobs" value={data.jobs_queued} />
+          <StatCard title="Failed jobs" value={data.jobs_failed} />
+          <StatCard title="Dead-letter jobs" value={data.jobs_dead_letter} />
+          <StatCard title="Queue depth" value={data.queue_depth} />
+          <StatCard title="Jobs last hour" value={data.jobs_last_hour} />
+        </div>
+      </section>
+
+      <section style={{ display: 'grid', gap: 12 }}>
+        <h2 style={{ margin: 0 }}>Performance metrics</h2>
+        <div style={{ display: 'grid', gap: 12, gridTemplateColumns: 'repeat(auto-fill, minmax(220px, 1fr))' }}>
+          <StatCard title="Avg processing (ms)" value={data.avg_processing_time_ms} />
+          <StatCard title="P95 processing (ms)" value={data.p95_processing_time_ms} />
+          <StatCard title="Success rate (1h)" value={`${(data.jobs_success_rate * 100).toFixed(1)}%`} />
+          <StatCard title="Success rate (24h)" value={`${(data.jobs_success_rate_24h * 100).toFixed(1)}%`} />
+        </div>
+      </section>
+
+      <section style={{ display: 'grid', gap: 12 }}>
+        <h2 style={{ margin: 0 }}>Economic metrics</h2>
+        <div style={{ display: 'grid', gap: 12, gridTemplateColumns: 'repeat(auto-fill, minmax(220px, 1fr))' }}>
+          <StatCard title="Credits consumed (1h)" value={data.credits_consumed_last_hour} />
+          <StatCard title="Revenue (1h)" value={`$${data.revenue_last_hour_usd.toFixed(2)}`} />
+          <StatCard title="Cost (1h)" value={`$${data.cost_last_hour_usd.toFixed(2)}`} />
+          <StatCard title="Margin (1h)" value={`$${data.margin_last_hour_usd.toFixed(2)}`} />
+          <StatCard title="Revenue (today)" value={`$${data.revenue_today_usd.toFixed(2)}`} />
+          <StatCard title="Cost (today)" value={`$${data.cost_today_usd.toFixed(2)}`} />
+          <StatCard title="Margin (today)" value={`$${data.margin_today_usd.toFixed(2)}`} />
+        </div>
+      </section>
+
+      <p style={{ margin: 0, color: '#6b7280', fontSize: 12 }}>
+        Auto-refresh every 12 seconds. Last refreshed: {new Date(data.refreshed_at).toLocaleString()}
+      </p>
+    </div>
+  );
+}


### PR DESCRIPTION
### Motivation
- Provide an internal admin monitoring surface for Phase 23 to expose job throughput, success/failure rates, queue health, latency (avg/p95), dead-letter counts, and simple unit-economics (revenue / cost / margin) for operational visibility.
- Skills used: none (no external skill files invoked for this change).

### Description
- Added a new admin-only metrics API `GET /api/admin/monitoring` implemented at `apps/web/app/api/admin/monitoring/route.ts` that enforces admin access via `x-admin-secret` / `ADMIN_SECRET`, aggregates data from `jobs` and `job_costs`, computes success rates, avg + p95 latencies, queue/dead-letter counts, and economic metrics (1h + today), and optionally fetches system health from `WORKER_API_BASE_URL`'s `/api/health` when configured.
- Added a server-rendered admin route `GET /admin/monitoring` at `apps/web/app/admin/monitoring/page.tsx` that validates an `admin_secret` query parameter and renders the dashboard when authorized.
- Added a client dashboard component `apps/web/components/AdminMonitoringDashboard.tsx` that polls the new API every ~12 seconds and renders system status, job processing counters, performance metrics, and economic metrics with loading/error states.
- Fixed an import path for `withSafeApiHandler` in the new API file and committed the three new files.

### Testing
- Ran `npm run typecheck` which initially failed due to an unrelated missing module import (`@pat87creator/alerts/dispatcher`) in another file; fixing the unrelated import is outside this change (typecheck still fails for that unrelated issue).
- After the `withSafeApiHandler` import path fix, the Next.js dev server was started with environment variables and reported `Local: http://localhost:3000` successfully (server start succeeded).
- Attempted an automated Playwright screenshot of `/admin/monitoring?admin_secret=secret` which failed in this environment due to a browser crash (SIGSEGV) and produced no screenshot.
- The new API and dashboard were committed and a follow-up PR was opened with these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7e7a4276483319ffed9632bfbedc3)