### PR TITLE
Phase 25: monitoring/reconciliation optimizations, worker concurrency, and DB indexes

### DIFF
--- a/apps/web/app/api/admin/monitoring/route.ts
+++ b/apps/web/app/api/admin/monitoring/route.ts
@@ -1,19 +1,17 @@
-import { createClient } from '@supabase/supabase-js';
+import { createClient, type SupabaseClient } from '@supabase/supabase-js';
 import { getRequiredEnv } from '@pat87creator/config/env';
 import { withSafeApiHandler } from '../../_lib/safeHandler';
 import { buildBillingReconciliationReport } from '../reconcile/_lib/reconciliation';
 
 type JobStatus = 'queued' | 'processing' | 'completed' | 'failed';
 
-type JobRow = {
-  status: JobStatus;
-  attempt_count: number;
+type JobRevenueRow = {
   billed_credits: number;
-  created_at: string;
-  processing_started_at: string | null;
-  processing_completed_at: string | null;
-  execution_duration_ms: number | null;
   revenue_usd: number | null;
+};
+
+type JobDurationRow = {
+  execution_duration_ms: number | null;
 };
 
 type JobCostRow = {
@@ -31,9 +29,14 @@ type HealthResponse = {
 const MAX_DEAD_LETTER_ATTEMPTS = 3;
 const ONE_HOUR_MS = 60 * 60 * 1000;
 const ONE_DAY_MS = 24 * ONE_HOUR_MS;
+const MONITORING_CACHE_TTL_MS = 5_000;
+const DEFAULT_QUEUE_BACKLOG_THRESHOLD = 20;
+const DEFAULT_WORKER_CONCURRENCY = 5;
 
 const supabaseUrl = getRequiredEnv('NEXT_PUBLIC_SUPABASE_URL');
 const serviceRoleKey = getRequiredEnv('SUPABASE_SERVICE_ROLE_KEY');
+
+let cachedResponse: { expiresAt: number; payload: Record<string, unknown> } | null = null;
 
 function percentile(values: number[], p: number): number {
   if (values.length === 0) {
@@ -53,6 +56,16 @@ function sum(values: number[]): number {
 
 function toBoolean(value: unknown): boolean {
   return value === true;
+}
+
+function getEnvNumber(name: string, fallback: number): number {
+  const raw = process.env[name];
+  if (!raw) {
+    return fallback;
+  }
+
+  const parsed = Number.parseInt(raw, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
 }
 
 async function fetchSystemHealth(adminSecret: string, request: Request): Promise<{ db: boolean; queue: boolean; stripe: boolean }> {
@@ -93,6 +106,33 @@ async function fetchSystemHealth(adminSecret: string, request: Request): Promise
   }
 }
 
+async function countJobs(
+  client: SupabaseClient<any, any, any>,
+  filters: { status?: JobStatus; since?: string; deadLetter?: boolean }
+): Promise<number> {
+  let query = client.from('jobs').select('id', { count: 'exact', head: true });
+
+  if (filters.status) {
+    query = query.eq('status', filters.status);
+  }
+
+  if (filters.since) {
+    query = query.gte('created_at', filters.since);
+  }
+
+  if (filters.deadLetter) {
+    query = query.eq('status', 'failed').gte('attempt_count', MAX_DEAD_LETTER_ATTEMPTS);
+  }
+
+  const { count, error } = await query;
+
+  if (error) {
+    throw new Error(error.message);
+  }
+
+  return count ?? 0;
+}
+
 export const GET = withSafeApiHandler('/api/admin/monitoring', async (request: Request) => {
   const adminSecret = getRequiredEnv('ADMIN_SECRET');
   const incomingSecret = request.headers.get('x-admin-secret');
@@ -101,10 +141,16 @@ export const GET = withSafeApiHandler('/api/admin/monitoring', async (request: R
     return Response.json({ error: 'Unauthorized' }, { status: 401 });
   }
 
+  if (cachedResponse && Date.now() < cachedResponse.expiresAt) {
+    return Response.json(cachedResponse.payload);
+  }
+
   const now = Date.now();
   const hourAgoIso = new Date(now - ONE_HOUR_MS).toISOString();
   const dayAgoIso = new Date(now - ONE_DAY_MS).toISOString();
   const todayStartIso = new Date(new Date().setHours(0, 0, 0, 0)).toISOString();
+  const workerConcurrency = getEnvNumber('WORKER_CONCURRENCY', DEFAULT_WORKER_CONCURRENCY);
+  const queueBacklogThreshold = getEnvNumber('QUEUE_BACKLOG_THRESHOLD', DEFAULT_QUEUE_BACKLOG_THRESHOLD);
 
   const client = createClient(supabaseUrl, serviceRoleKey, {
     auth: {
@@ -113,69 +159,75 @@ export const GET = withSafeApiHandler('/api/admin/monitoring', async (request: R
     }
   });
 
-  const jobsQuery = client
-    .from('jobs')
-    .select(
-      'status, attempt_count, billed_credits, created_at, processing_started_at, processing_completed_at, execution_duration_ms, revenue_usd'
-    )
-    .gte('created_at', dayAgoIso);
-
-  const jobCostsQuery = client.from('job_costs').select('amount_usd, created_at').gte('created_at', todayStartIso);
-
-  const [jobsResult, costsResult, health] = await Promise.all([
-    jobsQuery.returns<JobRow[]>(),
-    jobCostsQuery.returns<JobCostRow[]>(),
-    fetchSystemHealth(adminSecret, request)
+  const [
+    jobsLastHour,
+    jobsLast24Hours,
+    completedHour,
+    completedDay,
+    queuedJobs,
+    activeJobs,
+    failedJobs,
+    deadLetterJobs,
+    hourRevenueRowsResult,
+    dayDurationRowsResult,
+    costsTodayResult,
+    health,
+    billingIntegrity
+  ] = await Promise.all([
+    countJobs(client, { since: hourAgoIso }),
+    countJobs(client, { since: dayAgoIso }),
+    countJobs(client, { status: 'completed', since: hourAgoIso }),
+    countJobs(client, { status: 'completed', since: dayAgoIso }),
+    countJobs(client, { status: 'queued' }),
+    countJobs(client, { status: 'processing' }),
+    countJobs(client, { status: 'failed', since: dayAgoIso }),
+    countJobs(client, { deadLetter: true }),
+    client.from('jobs').select('billed_credits, revenue_usd').gte('created_at', hourAgoIso).returns<JobRevenueRow[]>(),
+    client
+      .from('jobs')
+      .select('execution_duration_ms')
+      .eq('status', 'completed')
+      .gte('created_at', dayAgoIso)
+      .returns<JobDurationRow[]>(),
+    client.from('job_costs').select('amount_usd, created_at').gte('created_at', todayStartIso).returns<JobCostRow[]>(),
+    fetchSystemHealth(adminSecret, request),
+    buildBillingReconciliationReport({ since: dayAgoIso })
   ]);
 
-  const billingIntegrity = await buildBillingReconciliationReport();
-
-  if (jobsResult.error) {
+  if (hourRevenueRowsResult.error || dayDurationRowsResult.error || costsTodayResult.error) {
     return Response.json({ error: 'internal_server_error' }, { status: 500 });
   }
 
-  if (costsResult.error) {
-    return Response.json({ error: 'internal_server_error' }, { status: 500 });
-  }
+  const hourRevenueRows = hourRevenueRowsResult.data ?? [];
+  const dayDurationRows = dayDurationRowsResult.data ?? [];
+  const costsToday = costsTodayResult.data ?? [];
 
-  const jobs = jobsResult.data ?? [];
-  const costs = costsResult.data ?? [];
-
-  const hourJobs = jobs.filter((job) => new Date(job.created_at).getTime() >= now - ONE_HOUR_MS);
-  const dayJobs = jobs;
-
-  const completedDurations = jobs
+  const completedDurations = dayDurationRows
     .map((job) => job.execution_duration_ms ?? null)
     .filter((value): value is number => typeof value === 'number' && Number.isFinite(value));
 
-  const creditsConsumedLastHour = sum(hourJobs.map((job) => job.billed_credits ?? 0));
-  const revenueLastHour = sum(hourJobs.map((job) => job.revenue_usd ?? 0));
+  const creditsConsumedLastHour = sum(hourRevenueRows.map((job) => job.billed_credits ?? 0));
+  const revenueLastHour = sum(hourRevenueRows.map((job) => job.revenue_usd ?? 0));
 
-  const hourCostRows = costs.filter((cost) => new Date(cost.created_at).getTime() >= now - ONE_HOUR_MS);
-  const costLastHour = sum(hourCostRows.map((cost) => cost.amount_usd ?? 0));
+  const nowMs = now;
+  const costLastHour = sum(
+    costsToday
+      .filter((cost) => new Date(cost.created_at).getTime() >= nowMs - ONE_HOUR_MS)
+      .map((cost) => Number(cost.amount_usd ?? 0))
+  );
+  const costToday = sum(costsToday.map((cost) => Number(cost.amount_usd ?? 0)));
 
-  const todayCostRows = costs.filter((cost) => new Date(cost.created_at).getTime() >= new Date(todayStartIso).getTime());
-  const costToday = sum(todayCostRows.map((cost) => cost.amount_usd ?? 0));
+  const successRateHour = jobsLastHour > 0 ? completedHour / jobsLastHour : 0;
+  const successRateDay = jobsLast24Hours > 0 ? completedDay / jobsLast24Hours : 0;
+  const queueDepth = queuedJobs + activeJobs;
+  const queueBacklogSize = Math.max(queuedJobs - queueBacklogThreshold, 0);
+  const jobsPerMinute = Number((jobsLastHour / 60).toFixed(2));
+  const workerUtilization = Number(Math.min(1, activeJobs / workerConcurrency).toFixed(4));
 
-  const todayJobs = jobs.filter((job) => new Date(job.created_at).getTime() >= new Date(todayStartIso).getTime());
-  const revenueToday = sum(todayJobs.map((job) => job.revenue_usd ?? 0));
-
-  const completedHour = hourJobs.filter((job) => job.status === 'completed').length;
-  const completedDay = dayJobs.filter((job) => job.status === 'completed').length;
-
-  const successRateHour = hourJobs.length > 0 ? completedHour / hourJobs.length : 0;
-  const successRateDay = dayJobs.length > 0 ? completedDay / dayJobs.length : 0;
-
-  const activeJobs = jobs.filter((job) => job.status === 'processing').length;
-  const queuedJobs = jobs.filter((job) => job.status === 'queued').length;
-  const failedJobs = jobs.filter((job) => job.status === 'failed').length;
-  const deadLetterJobs = jobs.filter(
-    (job) => job.status === 'failed' && (job.attempt_count ?? 0) >= MAX_DEAD_LETTER_ATTEMPTS
-  ).length;
-
-  return Response.json({
-    jobs_last_hour: hourJobs.length,
-    jobs_last_24_hours: dayJobs.length,
+  const payload: Record<string, unknown> = {
+    jobs_last_hour: jobsLastHour,
+    jobs_last_24_hours: jobsLast24Hours,
+    jobs_per_minute: jobsPerMinute,
     jobs_success_rate: Number(successRateHour.toFixed(4)),
     jobs_success_rate_24h: Number(successRateDay.toFixed(4)),
     jobs_failed: failedJobs,
@@ -183,17 +235,21 @@ export const GET = withSafeApiHandler('/api/admin/monitoring', async (request: R
     avg_processing_time_ms: completedDurations.length > 0 ? Math.round(sum(completedDurations) / completedDurations.length) : 0,
     p95_processing_time_ms: percentile(completedDurations, 95),
     active_jobs: activeJobs,
-    queue_depth: queuedJobs + activeJobs,
+    queue_depth: queueDepth,
+    queue_backlog_size: queueBacklogSize,
+    queue_backlog_threshold: queueBacklogThreshold,
     jobs_processing: activeJobs,
     jobs_queued: queuedJobs,
     jobs_dead_letter: deadLetterJobs,
+    worker_concurrency: workerConcurrency,
+    worker_utilization: workerUtilization,
     credits_consumed_last_hour: creditsConsumedLastHour,
     revenue_last_hour_usd: Number(revenueLastHour.toFixed(2)),
     cost_last_hour_usd: Number(costLastHour.toFixed(2)),
     margin_last_hour_usd: Number((revenueLastHour - costLastHour).toFixed(2)),
-    revenue_today_usd: Number(revenueToday.toFixed(2)),
+    revenue_today_usd: Number(billingIntegrity.totals.jobs_revenue_usd.toFixed(2)),
     cost_today_usd: Number(costToday.toFixed(2)),
-    margin_today_usd: Number((revenueToday - costToday).toFixed(2)),
+    margin_today_usd: Number((billingIntegrity.totals.jobs_revenue_usd - costToday).toFixed(2)),
     billing_integrity: {
       payments_verified: billingIntegrity.payments_checked,
       credit_mismatches: billingIntegrity.credit_mismatches,
@@ -201,9 +257,17 @@ export const GET = withSafeApiHandler('/api/admin/monitoring', async (request: R
       anomaly_count: billingIntegrity.anomalies.length,
       negative_margin_jobs: billingIntegrity.negative_margin_jobs,
       credits_verified: billingIntegrity.credits_verified,
-      last_reconciled_at: billingIntegrity.generated_at
+      last_reconciled_at: billingIntegrity.generated_at,
+      since: billingIntegrity.since
     },
     system_health: health,
     refreshed_at: new Date().toISOString()
-  });
+  };
+
+  cachedResponse = {
+    expiresAt: Date.now() + MONITORING_CACHE_TTL_MS,
+    payload
+  };
+
+  return Response.json(payload);
 });

--- a/apps/web/app/api/admin/reconcile/_lib/reconciliation.ts
+++ b/apps/web/app/api/admin/reconcile/_lib/reconciliation.ts
@@ -11,6 +11,7 @@ const stripe = new Stripe(stripeSecretKey, {
 });
 
 const STRIPE_SCAN_LIMIT = 500;
+const DEFAULT_RECONCILIATION_WINDOW_MS = 24 * 60 * 60 * 1000;
 
 type PaymentRow = {
   id: string;
@@ -52,6 +53,7 @@ type ReconciliationAnomaly = {
 
 export type BillingReconciliationReport = {
   generated_at: string;
+  since: string;
   payments_checked: number;
   credits_verified: boolean;
   credit_mismatches: number;
@@ -67,6 +69,10 @@ export type BillingReconciliationReport = {
   };
 };
 
+export type ReconciliationOptions = {
+  since?: string;
+};
+
 function roundCurrency(value: number): number {
   return Number(value.toFixed(2));
 }
@@ -75,9 +81,28 @@ function centsToUsd(amountCents: number): number {
   return amountCents / 100;
 }
 
-async function fetchSucceededStripePaymentIntents(): Promise<Stripe.PaymentIntent[]> {
+function resolveSince(since?: string): string {
+  if (!since) {
+    return new Date(Date.now() - DEFAULT_RECONCILIATION_WINDOW_MS).toISOString();
+  }
+
+  const parsed = new Date(since);
+  if (Number.isNaN(parsed.getTime())) {
+    throw new Error('Invalid since timestamp');
+  }
+
+  return parsed.toISOString();
+}
+
+async function fetchSucceededStripePaymentIntents(sinceIso: string): Promise<Stripe.PaymentIntent[]> {
   const intents: Stripe.PaymentIntent[] = [];
-  const iterator = stripe.paymentIntents.list({ limit: 100 });
+  const sinceEpochSeconds = Math.floor(new Date(sinceIso).getTime() / 1000);
+  const iterator = stripe.paymentIntents.list({
+    limit: 100,
+    created: {
+      gte: sinceEpochSeconds
+    }
+  });
 
   for await (const paymentIntent of iterator) {
     if (paymentIntent.status === 'succeeded') {
@@ -92,7 +117,9 @@ async function fetchSucceededStripePaymentIntents(): Promise<Stripe.PaymentInten
   return intents;
 }
 
-export async function buildBillingReconciliationReport(): Promise<BillingReconciliationReport> {
+export async function buildBillingReconciliationReport(options: ReconciliationOptions = {}): Promise<BillingReconciliationReport> {
+  const sinceIso = resolveSince(options.since);
+
   const supabase = createClient(supabaseUrl, serviceRoleKey, {
     auth: {
       persistSession: false,
@@ -101,15 +128,25 @@ export async function buildBillingReconciliationReport(): Promise<BillingReconci
   });
 
   const [stripePayments, paymentsResult, paymentEventsResult, jobsResult, jobCostsResult] = await Promise.all([
-    fetchSucceededStripePaymentIntents(),
-    supabase.from('payments').select('id, provider_reference, amount_cents, status').eq('status', 'succeeded').returns<PaymentRow[]>(),
+    fetchSucceededStripePaymentIntents(sinceIso),
+    supabase
+      .from('payments')
+      .select('id, provider_reference, amount_cents, status')
+      .eq('status', 'succeeded')
+      .gte('created_at', sinceIso)
+      .returns<PaymentRow[]>(),
     supabase
       .from('payment_events')
       .select('id, provider_reference, amount_cents, status')
       .eq('status', 'succeeded')
+      .gte('created_at', sinceIso)
       .returns<PaymentEventRow[]>(),
-    supabase.from('jobs').select('id, billed_credits, revenue_usd').returns<JobRow[]>(),
-    supabase.from('job_costs').select('job_id, amount_usd').returns<JobCostRow[]>()
+    supabase.from('jobs').select('id, billed_credits, revenue_usd').gte('created_at', sinceIso).returns<JobRow[]>(),
+    supabase
+      .from('job_costs')
+      .select('job_id, amount_usd')
+      .gte('created_at', sinceIso)
+      .returns<JobCostRow[]>()
   ]);
 
   if (paymentsResult.error || paymentEventsResult.error || jobsResult.error || jobCostsResult.error) {
@@ -254,6 +291,7 @@ export async function buildBillingReconciliationReport(): Promise<BillingReconci
 
   return {
     generated_at: new Date().toISOString(),
+    since: sinceIso,
     payments_checked: stripePayments.length,
     credits_verified: creditMismatches === 0,
     credit_mismatches: creditMismatches,

--- a/apps/web/app/api/admin/reconcile/payments/route.ts
+++ b/apps/web/app/api/admin/reconcile/payments/route.ts
@@ -10,7 +10,8 @@ export const POST = withSafeApiHandler('/api/admin/reconcile/payments', async (r
     return Response.json({ error: 'Unauthorized' }, { status: 401 });
   }
 
-  const report = await buildBillingReconciliationReport();
+  const since = new URL(request.url).searchParams.get('since') ?? undefined;
+  const report = await buildBillingReconciliationReport({ since });
 
   return Response.json(report, { status: 200 });
 });

--- a/apps/web/app/api/admin/reconcile/report/route.ts
+++ b/apps/web/app/api/admin/reconcile/report/route.ts
@@ -10,7 +10,8 @@ export const GET = withSafeApiHandler('/api/admin/reconcile/report', async (requ
     return Response.json({ error: 'Unauthorized' }, { status: 401 });
   }
 
-  const report = await buildBillingReconciliationReport();
+  const since = new URL(request.url).searchParams.get('since') ?? undefined;
+  const report = await buildBillingReconciliationReport({ since });
 
   return Response.json(report, { status: 200 });
 });

--- a/apps/web/components/AdminMonitoringDashboard.tsx
+++ b/apps/web/components/AdminMonitoringDashboard.tsx
@@ -23,6 +23,11 @@ type MonitoringResponse = {
   revenue_today_usd: number;
   cost_today_usd: number;
   margin_today_usd: number;
+  jobs_per_minute: number;
+  queue_backlog_size: number;
+  queue_backlog_threshold: number;
+  worker_concurrency: number;
+  worker_utilization: number;
   billing_integrity: {
     payments_verified: number;
     credit_mismatches: number;
@@ -31,6 +36,7 @@ type MonitoringResponse = {
     negative_margin_jobs: number;
     credits_verified: boolean;
     last_reconciled_at: string;
+    since: string;
   };
   system_health: {
     db: boolean;
@@ -143,6 +149,7 @@ export function AdminMonitoringDashboard({ adminSecret }: { adminSecret: string 
           <StatCard title="Failed jobs" value={data.jobs_failed} />
           <StatCard title="Dead-letter jobs" value={data.jobs_dead_letter} />
           <StatCard title="Queue depth" value={data.queue_depth} />
+          <StatCard title="Queue backlog" value={data.queue_backlog_size} />
           <StatCard title="Jobs last hour" value={data.jobs_last_hour} />
         </div>
       </section>
@@ -154,6 +161,8 @@ export function AdminMonitoringDashboard({ adminSecret }: { adminSecret: string 
           <StatCard title="P95 processing (ms)" value={data.p95_processing_time_ms} />
           <StatCard title="Success rate (1h)" value={`${(data.jobs_success_rate * 100).toFixed(1)}%`} />
           <StatCard title="Success rate (24h)" value={`${(data.jobs_success_rate_24h * 100).toFixed(1)}%`} />
+          <StatCard title="Jobs/minute" value={data.jobs_per_minute} />
+          <StatCard title="Worker utilization" value={`${(data.worker_utilization * 100).toFixed(1)}%`} />
         </div>
       </section>
 
@@ -187,6 +196,9 @@ export function AdminMonitoringDashboard({ adminSecret }: { adminSecret: string 
 
       <p style={{ margin: 0, color: '#6b7280', fontSize: 12 }}>
         Auto-refresh every 12 seconds. Last refreshed: {new Date(data.refreshed_at).toLocaleString()}
+      </p>
+      <p style={{ margin: 0, color: '#6b7280', fontSize: 12 }}>
+        Worker concurrency: {data.worker_concurrency}. Queue backlog threshold: {data.queue_backlog_threshold}.
       </p>
     </div>
   );

--- a/apps/worker-consumer/src/index.ts
+++ b/apps/worker-consumer/src/index.ts
@@ -1,4 +1,4 @@
-import { createClient } from '@supabase/supabase-js';
+import { createClient, type SupabaseClient } from '@supabase/supabase-js';
 import { dispatchAlert } from '@pat87creator/alerts/dispatcher';
 import { log } from '@pat87creator/logger';
 
@@ -43,6 +43,7 @@ type Env = {
   SUPABASE_ARTIFACT_BUCKET?: string;
   ALERT_SLACK_WEBHOOK_URL?: string;
   ALERT_EMAIL_TO?: string;
+  WORKER_CONCURRENCY?: string;
 };
 
 const MAX_RETRIES = 3;
@@ -50,6 +51,7 @@ const PROCESSING_TIMEOUT_MS = 5 * 60 * 1000;
 const DEFAULT_ARTIFACT_BUCKET = 'videos';
 const COMPUTE_COST_PER_SECOND_USD = 0.0004;
 const CREDIT_PRICE_USD = 0.01;
+const DEFAULT_WORKER_CONCURRENCY = 5;
 
 if ('addEventListener' in globalThis) {
   globalThis.addEventListener('unhandledrejection', (event) => {
@@ -100,8 +102,12 @@ function isLockExpired(lockedAt: string | null): boolean {
   return Date.now() - new Date(lockedAt).getTime() >= PROCESSING_TIMEOUT_MS;
 }
 
-async function fetchJob(env: Env, jobId: string): Promise<JobRow | null> {
-  const client = createServiceClient(env);
+function getWorkerConcurrency(env: Env): number {
+  const parsed = Number.parseInt(env.WORKER_CONCURRENCY ?? '', 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_WORKER_CONCURRENCY;
+}
+
+async function fetchJob(client: SupabaseClient, jobId: string): Promise<JobRow | null> {
   const { data, error } = await client
     .from('jobs')
     .select('id, status, attempt_count, locked_at, processing_token, result_payload, processing_started_at')
@@ -115,8 +121,7 @@ async function fetchJob(env: Env, jobId: string): Promise<JobRow | null> {
   return data;
 }
 
-async function startProcessing(env: Env, job: JobRow): Promise<StartedJob> {
-  const client = createServiceClient(env);
+async function startProcessing(client: SupabaseClient, job: JobRow): Promise<StartedJob> {
   const nextAttemptCount = job.attempt_count + 1;
   const nowIso = new Date().toISOString();
   const processingToken = crypto.randomUUID();
@@ -153,8 +158,7 @@ async function startProcessing(env: Env, job: JobRow): Promise<StartedJob> {
   };
 }
 
-async function artifactExists(env: Env, artifactPath: string): Promise<boolean> {
-  const client = createServiceClient(env);
+async function artifactExists(client: SupabaseClient, env: Env, artifactPath: string): Promise<boolean> {
   const bucket = env.SUPABASE_ARTIFACT_BUCKET || DEFAULT_ARTIFACT_BUCKET;
 
   const { data, error } = await client.storage.from(bucket).list('', {
@@ -170,13 +174,12 @@ async function artifactExists(env: Env, artifactPath: string): Promise<boolean> 
 }
 
 async function persistResultPayload(
-  env: Env,
+  client: SupabaseClient,
   jobId: string,
   attemptCount: number,
   processingToken: string,
   payload: JobResultPayload
 ): Promise<void> {
-  const client = createServiceClient(env);
   const { error } = await client
     .from('jobs')
     .update({ result_payload: payload })
@@ -191,7 +194,7 @@ async function persistResultPayload(
 }
 
 async function updateFinalStatus(
-  env: Env,
+  client: SupabaseClient,
   jobId: string,
   status: 'queued' | 'completed' | 'failed',
   attemptCount: number,
@@ -199,7 +202,6 @@ async function updateFinalStatus(
   processingStartedAt: string,
   errorMessage?: string
 ): Promise<number> {
-  const client = createServiceClient(env);
   const payload: {
     status: 'queued' | 'completed' | 'failed';
     locked_at: null;
@@ -239,8 +241,7 @@ async function updateFinalStatus(
   return durationMs;
 }
 
-async function finalizeJobEconomics(env: Env, jobId: string, executionDurationMs: number): Promise<void> {
-  const client = createServiceClient(env);
+async function finalizeJobEconomics(client: SupabaseClient, env: Env, jobId: string, executionDurationMs: number): Promise<void> {
   const computeCostUsd = (executionDurationMs / 1000) * COMPUTE_COST_PER_SECOND_USD;
 
   const { data, error } = await client.rpc('finalize_job_economics', {
@@ -288,14 +289,14 @@ async function simulateProcessing(): Promise<void> {
   await new Promise((resolve) => setTimeout(resolve, 100));
 }
 
-async function processMessage(message: Message<JobQueueMessage>, env: Env): Promise<void> {
+async function processMessage(message: Message<JobQueueMessage>, env: Env, client: SupabaseClient): Promise<void> {
   const body = message.body;
 
   if (!body?.job_id) {
     throw new Error('Queue message missing job_id');
   }
 
-  const job = await fetchJob(env, body.job_id);
+  const job = await fetchJob(client, body.job_id);
 
   if (!job) {
     log('error', 'Job not found for queued message', { job_id: body.job_id, transition_reason: 'missing_job' });
@@ -345,7 +346,7 @@ async function processMessage(message: Message<JobQueueMessage>, env: Env): Prom
   let started: StartedJob | null = null;
 
   try {
-    started = await startProcessing(env, job);
+    started = await startProcessing(client, job);
 
     log('info', 'Transitioning job to processing', {
       job_id: body.job_id,
@@ -355,7 +356,7 @@ async function processMessage(message: Message<JobQueueMessage>, env: Env): Prom
       transition: `${job.status} -> processing`
     });
 
-    const refreshedJob = await fetchJob(env, body.job_id);
+    const refreshedJob = await fetchJob(client, body.job_id);
     if (!refreshedJob) {
       throw new Error('Job disappeared after processing transition');
     }
@@ -381,19 +382,19 @@ async function processMessage(message: Message<JobQueueMessage>, env: Env): Prom
       });
 
       const durationMs = await updateFinalStatus(
-        env,
+        client,
         body.job_id,
         'completed',
         started.attemptCount,
         started.processingToken,
         started.processingStartedAt
       );
-      await finalizeJobEconomics(env, body.job_id, durationMs);
+      await finalizeJobEconomics(client, env, body.job_id, durationMs);
       return;
     }
 
     const artifactPath = artifactPathForJob(body.job_id);
-    const existingArtifact = await artifactExists(env, artifactPath);
+    const existingArtifact = await artifactExists(client, env, artifactPath);
 
     if (existingArtifact) {
       const payload: JobResultPayload = {
@@ -410,16 +411,16 @@ async function processMessage(message: Message<JobQueueMessage>, env: Env): Prom
         artifact_path: artifactPath
       });
 
-      await persistResultPayload(env, body.job_id, started.attemptCount, started.processingToken, payload);
+      await persistResultPayload(client, body.job_id, started.attemptCount, started.processingToken, payload);
       const durationMs = await updateFinalStatus(
-        env,
+        client,
         body.job_id,
         'completed',
         started.attemptCount,
         started.processingToken,
         started.processingStartedAt
       );
-      await finalizeJobEconomics(env, body.job_id, durationMs);
+      await finalizeJobEconomics(client, env, body.job_id, durationMs);
       return;
     }
 
@@ -430,16 +431,16 @@ async function processMessage(message: Message<JobQueueMessage>, env: Env): Prom
       source: 'render'
     };
 
-    await persistResultPayload(env, body.job_id, started.attemptCount, started.processingToken, payload);
+    await persistResultPayload(client, body.job_id, started.attemptCount, started.processingToken, payload);
     const durationMs = await updateFinalStatus(
-      env,
+      client,
       body.job_id,
       'completed',
       started.attemptCount,
       started.processingToken,
       started.processingStartedAt
     );
-    await finalizeJobEconomics(env, body.job_id, durationMs);
+    await finalizeJobEconomics(client, env, body.job_id, durationMs);
 
     log('info', 'Transitioning job to completed', {
       job_id: body.job_id,
@@ -486,7 +487,7 @@ async function processMessage(message: Message<JobQueueMessage>, env: Env): Prom
 
     try {
       await updateFinalStatus(
-        env,
+        client,
         body.job_id,
         nextStatus,
         started.attemptCount,
@@ -536,16 +537,25 @@ export default {
       return;
     }
 
-    for (const message of batch.messages) {
-      try {
-        await processMessage(message, env);
-        message.ack();
-      } catch (error) {
-        log('error', 'Unhandled queue message error', {
-          message: error instanceof Error ? error.message : 'Unknown error'
-        });
-        message.retry();
-      }
+    const client = createServiceClient(env);
+    const concurrency = getWorkerConcurrency(env);
+
+    for (let index = 0; index < batch.messages.length; index += concurrency) {
+      const chunk = batch.messages.slice(index, index + concurrency);
+
+      await Promise.all(
+        chunk.map(async (message) => {
+          try {
+            await processMessage(message, env, client);
+            message.ack();
+          } catch (error) {
+            log('error', 'Unhandled queue message error', {
+              message: error instanceof Error ? error.message : 'Unknown error'
+            });
+            message.retry();
+          }
+        })
+      );
     }
   }
 };

--- a/packages/db/migrations/014_phase_25_scaling_indexes.sql
+++ b/packages/db/migrations/014_phase_25_scaling_indexes.sql
@@ -1,0 +1,25 @@
+CREATE INDEX IF NOT EXISTS idx_jobs_status_created_at
+  ON public.jobs (status, created_at DESC);
+
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND table_name = 'jobs'
+      AND column_name = 'user_id'
+  ) THEN
+    EXECUTE 'CREATE INDEX IF NOT EXISTS idx_jobs_user_created ON public.jobs (user_id, created_at DESC)';
+  END IF;
+END;
+$$;
+
+CREATE INDEX IF NOT EXISTS idx_job_costs_created
+  ON public.job_costs (created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_payments_user_created
+  ON public.payments (user_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_user_daily_usage_user_date
+  ON public.user_daily_usage (user_id, date DESC);


### PR DESCRIPTION
### Motivation
- Reduce database load and eliminate full-table scans in critical observability and reconciliation paths by adding targeted indexes and time-bounded queries.
- Make the admin monitoring endpoint safe to poll from the UI by adding short caching and index-friendly aggregations to lower DB pressure.
- Improve worker stability and throughput by introducing explicit concurrency control and reusing a single DB client per batch.

### Description
- Added a new DB migration `014_phase_25_scaling_indexes.sql` that creates indexes for `jobs(status, created_at)`, `job_costs(created_at)`, `payments(user_id, created_at)`, `user_daily_usage(user_id, date)`, and a conditional `jobs(user_id, created_at)` when `jobs.user_id` exists.
- Refactored `/api/admin/monitoring` to use count-head queries and time-windowed selects, added a 5s in-memory cache, and surfaced new metrics `jobs_per_minute`, `queue_backlog_size`, `worker_utilization`, and `worker_concurrency`.
- Updated reconciliation to accept an optional `since` parameter and default to a 24-hour window, constrained Stripe and Supabase queries to that window, and wired `?since=` through both reconciliation endpoints.
- Updated `worker-consumer` to reuse a single Supabase client per batch and process messages in bounded concurrent chunks controlled by `WORKER_CONCURRENCY` (default `5`), plus adjusted helpers to accept a shared client.
- Updated the admin dashboard types and UI cards to display the new scaling/backlog/utilization metrics.

### Testing
- Ran `npm run typecheck` and resolved type errors introduced by refactors, and the typecheck completed successfully.
- Built worker packages with `npm run build:worker-consumer` and `npm run build:worker-api` which succeeded in dry-run builds.
- Attempted `npm run build:web` which failed during route evaluation because required runtime env vars (e.g. `NEXT_PUBLIC_SUPABASE_URL`) are not provided in this environment, so server-side route evaluation blocks the full site build.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7edc4068883319eac10ea959b9057)