### PR TITLE
Follow-up: add @supabase/supabase-js to apps/web workspace dependencies

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -9,18 +9,19 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@pat87creator/alerts": "0.1.0",
+    "@pat87creator/config": "0.1.0",
+    "@pat87creator/logger": "0.1.0",
+    "@supabase/supabase-js": "^2.43.0",
     "next": "14.2.12",
     "react": "18.3.1",
     "react-dom": "18.3.1",
-    "stripe": "^16.10.0",
-    "@pat87creator/config": "0.1.0",
-    "@pat87creator/logger": "0.1.0",
-    "@pat87creator/alerts": "0.1.0"
+    "stripe": "^16.10.0"
   },
   "devDependencies": {
-    "typescript": "5.5.4",
     "@types/node": "20.14.15",
     "@types/react": "18.3.3",
-    "@types/react-dom": "18.3.0"
+    "@types/react-dom": "18.3.0",
+    "typescript": "5.5.4"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "@pat87creator/alerts": "0.1.0",
         "@pat87creator/config": "0.1.0",
         "@pat87creator/logger": "0.1.0",
+        "@supabase/supabase-js": "^2.43.0",
         "next": "14.2.12",
         "react": "18.3.1",
         "react-dom": "18.3.1",


### PR DESCRIPTION
### Motivation
- The web workspace imports `@supabase/supabase-js` from `apps/web/lib/supabase.ts` but did not declare it in `apps/web/package.json`, causing Cloudflare/Next.js builds to fail with a module not found error. 

### Description
- Added `@supabase/supabase-js` at range `^2.43.0` to `apps/web/package.json` so the web app directly declares the package it imports.
- Updated `package-lock.json` via workspace install so the lockfile reflects the new workspace dependency entry for `apps/web`.
- Modified `apps/web/package.json` devDependencies ordering (moved `typescript` to the end) to keep file formatting consistent.

### Testing
- Ran `npm install --workspace @pat87creator/web`, which completed successfully and updated the lockfile.
- Ran `npm run build --workspace @pat87creator/web` without env vars, which failed due to missing required environment variables (expected for CI-less environment).
- Ran `NEXT_PUBLIC_SUPABASE_URL=https://example.supabase.co NEXT_PUBLIC_SUPABASE_ANON_KEY=test SUPABASE_SERVICE_ROLE_KEY=test STRIPE_SECRET_KEY=test STRIPE_WEBHOOK_SECRET=test npm run build --workspace @pat87creator/web`, which completed the Next.js production build successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a93ae8d02883318bc75be0df41f4e9)