### PR TITLE
Follow-up: finalize Supabase workspace dependency and Cloudflare Pages deployment docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,3 +43,18 @@ Run web app locally:
 ```bash
 npm run dev:web
 ```
+
+
+## Cloudflare Pages configuration
+
+For production deployment of the web app, configure Cloudflare Pages with:
+
+- Root directory: `apps/web`
+- Build command: `npm run build`
+- Output directory: `.next`
+
+Required environment variables in Cloudflare Pages:
+
+- `NEXT_PUBLIC_SUPABASE_URL`
+- `NEXT_PUBLIC_SUPABASE_ANON_KEY`
+

--- a/apps/web/lib/supabase.ts
+++ b/apps/web/lib/supabase.ts
@@ -2,7 +2,4 @@
 
 import { createClient } from '@supabase/supabase-js';
 
-const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL ?? 'http://127.0.0.1:54321';
-const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ?? 'missing-anon-key';
-
-export const supabase = createClient(supabaseUrl, supabaseAnonKey);
+export const supabase = createClient(process.env.NEXT_PUBLIC_SUPABASE_URL!, process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!);

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -9,18 +9,19 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@pat87creator/alerts": "0.1.0",
+    "@pat87creator/config": "0.1.0",
+    "@pat87creator/logger": "0.1.0",
+    "@supabase/supabase-js": "^2.43.0",
     "next": "14.2.12",
     "react": "18.3.1",
     "react-dom": "18.3.1",
-    "stripe": "^16.10.0",
-    "@pat87creator/config": "0.1.0",
-    "@pat87creator/logger": "0.1.0",
-    "@pat87creator/alerts": "0.1.0"
+    "stripe": "^16.10.0"
   },
   "devDependencies": {
-    "typescript": "5.5.4",
     "@types/node": "20.14.15",
     "@types/react": "18.3.3",
-    "@types/react-dom": "18.3.0"
+    "@types/react-dom": "18.3.0",
+    "typescript": "5.5.4"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "@pat87creator/alerts": "0.1.0",
         "@pat87creator/config": "0.1.0",
         "@pat87creator/logger": "0.1.0",
+        "@supabase/supabase-js": "^2.43.0",
         "next": "14.2.12",
         "react": "18.3.1",
         "react-dom": "18.3.1",


### PR DESCRIPTION
### Motivation
- The `apps/web` workspace build on Cloudflare Pages failed due to a missing Supabase dependency and incorrect local Supabase initialization fallbacks. 
- The monorepo requires the web workspace to declare workspace-local dependencies so Cloudflare Pages resolves them during the `apps/web` build. 
- Cloudflare Pages needs documented build/root/output settings and required env vars so production deploys are reproducible. 

### Description
- Added `@supabase/supabase-js` to `apps/web/package.json` (pinned to `^2.43.0`) and refreshed the lockfile so the dependency is available during `apps/web` builds. 
- Replaced permissive local fallbacks in `apps/web/lib/supabase.ts` with explicit client initialization using `process.env.NEXT_PUBLIC_SUPABASE_URL!` and `process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!` to match expected production shape. 
- Added a Cloudflare Pages configuration section to `README.md` documenting `Root directory: apps/web`, `Build command: npm run build`, `Output directory: .next`, and the required env vars `NEXT_PUBLIC_SUPABASE_URL` and `NEXT_PUBLIC_SUPABASE_ANON_KEY`. 
- Left `.env.example` unchanged because it already contained the public Supabase variables. 

### Testing
- Ran `npm install` to refresh workspace deps and it completed successfully. 
- Running `npm run build --workspace @pat87creator/web` without env vars failed with the expected error about missing `NEXT_PUBLIC_SUPABASE_URL`. 
- Running `NEXT_PUBLIC_SUPABASE_URL=... NEXT_PUBLIC_SUPABASE_ANON_KEY=... SUPABASE_SERVICE_ROLE_KEY=... STRIPE_SECRET_KEY=... STRIPE_WEBHOOK_SECRET=... ADMIN_SECRET=... CLOUDFLARE_QUEUE=... npm run build --workspace @pat87creator/web` completed successfully. 
- Ran `npm run typecheck` and `tsc --noEmit` for the web workspace and it passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a93ce4661883318e37e95127134d52)