### PR TITLE
Phase 28 follow-up: add billing API, subscription credits, and dashboard usage metrics

### DIFF
--- a/apps/web/app/api/billing/create-checkout-session/route.ts
+++ b/apps/web/app/api/billing/create-checkout-session/route.ts
@@ -1,0 +1,86 @@
+import { createClient } from '@supabase/supabase-js';
+import { getRequiredEnv } from '@pat87creator/config/env';
+import Stripe from 'stripe';
+import { withSafeApiHandler } from '../../_lib/safeHandler';
+import { PLAN_BY_KEY, parsePlan } from '../../../../lib/billing';
+
+type CreateCheckoutSessionRequest = {
+  plan?: unknown;
+};
+
+const stripeSecretKey = getRequiredEnv('STRIPE_SECRET_KEY');
+const appUrl = process.env.NEXT_PUBLIC_APP_URL;
+
+if (!appUrl) {
+  throw new Error('Missing required environment variable: NEXT_PUBLIC_APP_URL');
+}
+const supabaseUrl = getRequiredEnv('NEXT_PUBLIC_SUPABASE_URL');
+const supabaseAnonKey = getRequiredEnv('NEXT_PUBLIC_SUPABASE_ANON_KEY');
+
+const stripe = new Stripe(stripeSecretKey, { apiVersion: '2024-06-20' });
+
+function getBearerToken(request: Request): string | null {
+  const authorizationHeader = request.headers.get('authorization');
+  if (!authorizationHeader?.startsWith('Bearer ')) {
+    return null;
+  }
+
+  return authorizationHeader.slice('Bearer '.length).trim() || null;
+}
+
+export const POST = withSafeApiHandler('/api/billing/create-checkout-session', async (request: Request) => {
+  const accessToken = getBearerToken(request);
+  if (!accessToken) {
+    return Response.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const authClient = createClient(supabaseUrl, supabaseAnonKey, {
+    auth: { persistSession: false, autoRefreshToken: false },
+    global: { headers: { Authorization: `Bearer ${accessToken}` } }
+  });
+
+  const {
+    data: { user },
+    error: userError
+  } = await authClient.auth.getUser();
+
+  if (userError || !user) {
+    return Response.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  let requestBody: CreateCheckoutSessionRequest;
+
+  try {
+    requestBody = (await request.json()) as CreateCheckoutSessionRequest;
+  } catch {
+    return Response.json({ error: 'Invalid JSON body' }, { status: 400 });
+  }
+
+  const plan = parsePlan(requestBody.plan);
+  if (!plan) {
+    return Response.json({ error: 'Invalid plan' }, { status: 400 });
+  }
+
+  const priceId = process.env[PLAN_BY_KEY[plan].stripePriceEnv];
+  if (!priceId) {
+    return Response.json({ error: `Missing env ${PLAN_BY_KEY[plan].stripePriceEnv}` }, { status: 500 });
+  }
+
+  const session = await stripe.checkout.sessions.create({
+    mode: 'subscription',
+    success_url: `${appUrl}/dashboard?checkout=success`,
+    cancel_url: `${appUrl}/dashboard?checkout=cancelled`,
+    line_items: [{ price: priceId, quantity: 1 }],
+    client_reference_id: user.id,
+    metadata: { user_id: user.id, plan },
+    subscription_data: {
+      metadata: { user_id: user.id, plan }
+    }
+  });
+
+  if (!session.url) {
+    return Response.json({ error: 'Failed to create checkout session' }, { status: 500 });
+  }
+
+  return Response.json({ url: session.url }, { status: 200 });
+});

--- a/apps/web/app/api/billing/monthly-reset/route.ts
+++ b/apps/web/app/api/billing/monthly-reset/route.ts
@@ -1,0 +1,26 @@
+import { createClient } from '@supabase/supabase-js';
+import { getRequiredEnv } from '@pat87creator/config/env';
+import { withSafeApiHandler } from '../../_lib/safeHandler';
+
+const supabaseUrl = getRequiredEnv('NEXT_PUBLIC_SUPABASE_URL');
+const serviceRoleKey = getRequiredEnv('SUPABASE_SERVICE_ROLE_KEY');
+
+export const POST = withSafeApiHandler('/api/billing/monthly-reset', async (request: Request) => {
+  const authHeader = request.headers.get('authorization');
+  const expectedToken = process.env.BILLING_CRON_SECRET;
+
+  if (expectedToken && authHeader !== `Bearer ${expectedToken}`) {
+    return Response.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const adminClient = createClient(supabaseUrl, serviceRoleKey, {
+    auth: { persistSession: false, autoRefreshToken: false }
+  });
+
+  const { error } = await adminClient.rpc('refresh_monthly_credits');
+  if (error) {
+    return Response.json({ error: 'Failed to refresh credits' }, { status: 500 });
+  }
+
+  return Response.json({ ok: true }, { status: 200 });
+});

--- a/apps/web/app/api/billing/subscription/route.ts
+++ b/apps/web/app/api/billing/subscription/route.ts
@@ -1,0 +1,54 @@
+import { createClient } from '@supabase/supabase-js';
+import { getRequiredEnv } from '@pat87creator/config/env';
+import { withSafeApiHandler } from '../../_lib/safeHandler';
+
+type SubscriptionRow = {
+  plan: string;
+  status: string;
+  current_period_end: string | null;
+};
+
+const supabaseUrl = getRequiredEnv('NEXT_PUBLIC_SUPABASE_URL');
+const supabaseAnonKey = getRequiredEnv('NEXT_PUBLIC_SUPABASE_ANON_KEY');
+
+function getBearerToken(request: Request): string | null {
+  const authorizationHeader = request.headers.get('authorization');
+  if (!authorizationHeader?.startsWith('Bearer ')) {
+    return null;
+  }
+
+  return authorizationHeader.slice('Bearer '.length).trim() || null;
+}
+
+export const GET = withSafeApiHandler('/api/billing/subscription', async (request: Request) => {
+  const accessToken = getBearerToken(request);
+  if (!accessToken) {
+    return Response.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const client = createClient(supabaseUrl, supabaseAnonKey, {
+    auth: { persistSession: false, autoRefreshToken: false },
+    global: { headers: { Authorization: `Bearer ${accessToken}` } }
+  });
+
+  const {
+    data: { user },
+    error: userError
+  } = await client.auth.getUser();
+
+  if (userError || !user) {
+    return Response.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const { data, error } = await client
+    .from('user_subscriptions')
+    .select('plan, status, current_period_end')
+    .eq('user_id', user.id)
+    .single<SubscriptionRow>();
+
+  if (error) {
+    return Response.json({ plan: 'free', status: 'inactive', current_period_end: null }, { status: 200 });
+  }
+
+  return Response.json(data, { status: 200 });
+});

--- a/apps/web/app/api/billing/usage/route.ts
+++ b/apps/web/app/api/billing/usage/route.ts
@@ -1,0 +1,75 @@
+import { createClient } from '@supabase/supabase-js';
+import { getRequiredEnv } from '@pat87creator/config/env';
+import { withSafeApiHandler } from '../../_lib/safeHandler';
+
+type UsageRow = {
+  credits_remaining: number;
+};
+
+const supabaseUrl = getRequiredEnv('NEXT_PUBLIC_SUPABASE_URL');
+const supabaseAnonKey = getRequiredEnv('NEXT_PUBLIC_SUPABASE_ANON_KEY');
+
+function getBearerToken(request: Request): string | null {
+  const authorizationHeader = request.headers.get('authorization');
+  if (!authorizationHeader?.startsWith('Bearer ')) {
+    return null;
+  }
+
+  return authorizationHeader.slice('Bearer '.length).trim() || null;
+}
+
+export const GET = withSafeApiHandler('/api/billing/usage', async (request: Request) => {
+  const accessToken = getBearerToken(request);
+  if (!accessToken) {
+    return Response.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const client = createClient(supabaseUrl, supabaseAnonKey, {
+    auth: { persistSession: false, autoRefreshToken: false },
+    global: { headers: { Authorization: `Bearer ${accessToken}` } }
+  });
+
+  const {
+    data: { user },
+    error: userError
+  } = await client.auth.getUser();
+
+  if (userError || !user) {
+    return Response.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const monthStart = new Date();
+  monthStart.setUTCDate(1);
+  monthStart.setUTCHours(0, 0, 0, 0);
+
+  const [creditsResult, usageResult, planResult, jobsResult] = await Promise.all([
+    client.from('users').select('credits_remaining').eq('id', user.id).single<UsageRow>(),
+    client
+      .from('jobs')
+      .select('id, videos!inner(user_id)', { count: 'exact', head: true })
+      .eq('videos.user_id', user.id)
+      .gte('created_at', monthStart.toISOString()),
+    client.from('user_subscriptions').select('plan, status').eq('user_id', user.id).single<{ plan: string; status: string }>(),
+    client
+      .from('jobs')
+      .select('id, status, created_at, videos!inner(user_id)')
+      .eq('videos.user_id', user.id)
+      .order('created_at', { ascending: false })
+      .limit(5)
+  ]);
+
+  return Response.json(
+    {
+      credits_remaining: creditsResult.data?.credits_remaining ?? 0,
+      renders_used_this_month: usageResult.count ?? 0,
+      subscription_plan: planResult.data?.plan ?? 'free',
+      subscription_status: planResult.data?.status ?? 'inactive',
+      job_history: (jobsResult.data ?? []).map((job) => ({
+        id: job.id,
+        status: job.status,
+        created_at: job.created_at
+      }))
+    },
+    { status: 200 }
+  );
+});

--- a/apps/web/app/api/billing/webhook/route.ts
+++ b/apps/web/app/api/billing/webhook/route.ts
@@ -1,0 +1,137 @@
+import { createClient } from '@supabase/supabase-js';
+import { getRequiredEnv } from '@pat87creator/config/env';
+import { withSafeApiHandler } from '../../_lib/safeHandler';
+import Stripe from 'stripe';
+
+const stripeSecretKey = getRequiredEnv('STRIPE_SECRET_KEY');
+const stripeWebhookSecret = getRequiredEnv('STRIPE_WEBHOOK_SECRET');
+const supabaseUrl = getRequiredEnv('NEXT_PUBLIC_SUPABASE_URL');
+const serviceRoleKey = getRequiredEnv('SUPABASE_SERVICE_ROLE_KEY');
+
+const stripe = new Stripe(stripeSecretKey, { apiVersion: '2024-06-20' });
+
+const supportedEvents = new Set([
+  'checkout.session.completed',
+  'invoice.payment_succeeded',
+  'customer.subscription.updated',
+  'customer.subscription.deleted'
+]);
+
+function toUnix(value: number | null | undefined): number | null {
+  return typeof value === 'number' ? value : null;
+}
+
+export const POST = withSafeApiHandler('/api/billing/webhook', async (request: Request) => {
+  const signature = request.headers.get('stripe-signature');
+  if (!signature) {
+    return new Response('Missing Stripe signature header', { status: 400 });
+  }
+
+  const body = await request.text();
+
+  let event: Stripe.Event;
+  try {
+    event = stripe.webhooks.constructEvent(body, signature, stripeWebhookSecret);
+  } catch {
+    return new Response('Invalid signature', { status: 400 });
+  }
+
+  if (!supportedEvents.has(event.type)) {
+    return new Response('Ignored event', { status: 200 });
+  }
+
+  const adminClient = createClient(supabaseUrl, serviceRoleKey, {
+    auth: { persistSession: false, autoRefreshToken: false }
+  });
+
+  if (event.type === 'checkout.session.completed') {
+    const session = event.data.object as Stripe.Checkout.Session;
+    const userId = session.metadata?.user_id ?? session.client_reference_id ?? undefined;
+    const subscriptionId = typeof session.subscription === 'string' ? session.subscription : null;
+    const customerId = typeof session.customer === 'string' ? session.customer : null;
+    const plan = session.metadata?.plan ?? null;
+
+    if (userId && subscriptionId) {
+      await adminClient.rpc('sync_user_subscription', {
+        p_user_id: userId,
+        p_plan: plan,
+        p_status: 'active',
+        p_stripe_subscription_id: subscriptionId,
+        p_stripe_customer_id: customerId,
+        p_current_period_end: null
+      });
+    }
+
+    return new Response('ok', { status: 200 });
+  }
+
+  if (event.type === 'invoice.payment_succeeded') {
+    const invoice = event.data.object as Stripe.Invoice;
+    const userId = invoice.subscription_details?.metadata?.user_id ?? invoice.lines.data[0]?.metadata?.user_id;
+    const plan = invoice.subscription_details?.metadata?.plan ?? invoice.lines.data[0]?.metadata?.plan ?? null;
+
+    const subscriptionId =
+      typeof invoice.subscription === 'string'
+        ? invoice.subscription
+        : invoice.subscription && 'id' in invoice.subscription
+          ? (invoice.subscription.id as string)
+          : null;
+
+    const customerId =
+      typeof invoice.customer === 'string'
+        ? invoice.customer
+        : invoice.customer && 'id' in invoice.customer
+          ? (invoice.customer.id as string)
+          : null;
+
+    if (userId) {
+      await adminClient.rpc('process_stripe_payment', {
+        p_user_id: userId,
+        p_provider_reference: event.id,
+        p_amount_cents: invoice.amount_paid,
+        p_currency: invoice.currency,
+        p_status: 'succeeded',
+        p_raw_payload: event.data.object
+      });
+
+      await adminClient.rpc('sync_user_subscription', {
+        p_user_id: userId,
+        p_plan: plan,
+        p_status: 'active',
+        p_stripe_subscription_id: subscriptionId,
+        p_stripe_customer_id: customerId,
+        p_current_period_end: toUnix(invoice.period_end)
+      });
+
+      await adminClient.rpc('apply_monthly_subscription_credits', { p_user_id: userId });
+    }
+
+    return new Response('ok', { status: 200 });
+  }
+
+  const subscription = event.data.object as Stripe.Subscription;
+  const userId = subscription.metadata?.user_id;
+  const plan = subscription.metadata?.plan ?? null;
+
+  if (!userId) {
+    return new Response('ok', { status: 200 });
+  }
+
+  const status = event.type === 'customer.subscription.deleted' ? 'canceled' : subscription.status;
+
+  await adminClient.rpc('sync_user_subscription', {
+    p_user_id: userId,
+    p_plan: plan,
+    p_status: status,
+    p_stripe_subscription_id: subscription.id,
+    p_stripe_customer_id:
+      typeof subscription.customer === 'string'
+        ? subscription.customer
+        : subscription.customer && 'id' in subscription.customer
+          ? (subscription.customer.id as string)
+          : null,
+    p_current_period_end: toUnix(subscription.current_period_end)
+  });
+
+  return new Response('ok', { status: 200 });
+});

--- a/apps/web/app/api/jobs/create/route.ts
+++ b/apps/web/app/api/jobs/create/route.ts
@@ -1,6 +1,7 @@
 import { createClient } from '@supabase/supabase-js';
 import { getRequiredEnv } from '@pat87creator/config/env';
 import { log } from '@pat87creator/logger';
+import { getVideoJobCost } from '../../../../lib/billing';
 import { withSafeApiHandler } from '../../_lib/safeHandler';
 
 type CreateJobRequest = {
@@ -34,7 +35,7 @@ type RuntimeWithQueue = typeof globalThis & {
   VIDEO_JOB_QUEUE?: QueueBinding;
 };
 
-const VIDEO_JOB_COST = 10;
+const VIDEO_JOB_COST = getVideoJobCost();
 const RATE_LIMIT_PREFIX = 'RATE_LIMIT_EXCEEDED|';
 
 const supabaseUrl = getRequiredEnv('NEXT_PUBLIC_SUPABASE_URL');

--- a/apps/web/components/DashboardClient.tsx
+++ b/apps/web/components/DashboardClient.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import { CreateVideoForm } from './CreateVideoForm';
 import { CreditBalance } from './CreditBalance';
 import { JobTable } from './JobTable';
+import { UsageMetrics } from './UsageMetrics';
 import { useToast } from './ToastProvider';
 import { supabase } from '../lib/supabase';
 
@@ -156,6 +157,7 @@ export function DashboardClient() {
 
   return (
     <>
+      <UsageMetrics refreshKey={refreshKey} />
       <CreditBalance refreshKey={refreshKey} />
       <CreateVideoForm onCreateJob={createJob} isSubmitting={isSubmitting} cooldownSeconds={cooldownSeconds} />
       <JobTable

--- a/apps/web/components/UsageMetrics.tsx
+++ b/apps/web/components/UsageMetrics.tsx
@@ -1,0 +1,58 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { supabase } from '../lib/supabase';
+
+type UsagePayload = {
+  credits_remaining: number;
+  renders_used_this_month: number;
+  subscription_plan: string;
+  subscription_status: string;
+};
+
+type UsageMetricsProps = {
+  refreshKey: number;
+};
+
+export function UsageMetrics({ refreshKey }: UsageMetricsProps) {
+  const [data, setData] = useState<UsagePayload | null>(null);
+
+  useEffect(() => {
+    const run = async () => {
+      const {
+        data: { session }
+      } = await supabase.auth.getSession();
+
+      if (!session?.access_token) {
+        setData(null);
+        return;
+      }
+
+      const response = await fetch('/api/billing/usage', {
+        headers: { Authorization: `Bearer ${session.access_token}` }
+      });
+
+      if (!response.ok) {
+        setData(null);
+        return;
+      }
+
+      const payload = (await response.json()) as UsagePayload;
+      setData(payload);
+    };
+
+    void run();
+  }, [refreshKey]);
+
+  if (!data) {
+    return <p>Usage metrics unavailable.</p>;
+  }
+
+  return (
+    <section style={{ marginBottom: 12 }}>
+      <p>Plan: {data.subscription_plan} ({data.subscription_status})</p>
+      <p>Remaining credits: {data.credits_remaining}</p>
+      <p>Renders used this month: {data.renders_used_this_month}</p>
+    </section>
+  );
+}

--- a/apps/web/lib/billing.ts
+++ b/apps/web/lib/billing.ts
@@ -1,0 +1,44 @@
+export type SubscriptionPlan = 'starter' | 'creator' | 'pro';
+
+export type PlanDefinition = {
+  key: SubscriptionPlan;
+  label: string;
+  monthlyCredits: number;
+  stripePriceEnv: string;
+};
+
+export const PLAN_DEFINITIONS: PlanDefinition[] = [
+  { key: 'starter', label: 'Starter', monthlyCredits: 10, stripePriceEnv: 'STRIPE_PRICE_STARTER' },
+  { key: 'creator', label: 'Creator', monthlyCredits: 50, stripePriceEnv: 'STRIPE_PRICE_CREATOR' },
+  { key: 'pro', label: 'Pro', monthlyCredits: 200, stripePriceEnv: 'STRIPE_PRICE_PRO' }
+];
+
+export const PLAN_BY_KEY: Record<SubscriptionPlan, PlanDefinition> = {
+  starter: PLAN_DEFINITIONS[0],
+  creator: PLAN_DEFINITIONS[1],
+  pro: PLAN_DEFINITIONS[2]
+};
+
+const DEFAULT_VIDEO_JOB_COST = 10;
+
+export function getVideoJobCost(): number {
+  const rawValue = process.env.VIDEO_JOB_COST;
+  if (!rawValue) {
+    return DEFAULT_VIDEO_JOB_COST;
+  }
+
+  const parsed = Number.parseInt(rawValue, 10);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    return DEFAULT_VIDEO_JOB_COST;
+  }
+
+  return parsed;
+}
+
+export function parsePlan(input: unknown): SubscriptionPlan | null {
+  if (input === 'starter' || input === 'creator' || input === 'pro') {
+    return input;
+  }
+
+  return null;
+}

--- a/packages/db/migrations/015_phase_28_billing_subscriptions.sql
+++ b/packages/db/migrations/015_phase_28_billing_subscriptions.sql
@@ -1,0 +1,171 @@
+CREATE TABLE IF NOT EXISTS public.subscription_plans (
+  id TEXT PRIMARY KEY,
+  display_name TEXT NOT NULL,
+  monthly_credits INTEGER NOT NULL CHECK (monthly_credits > 0),
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+INSERT INTO public.subscription_plans (id, display_name, monthly_credits)
+VALUES
+  ('starter', 'Starter', 10),
+  ('creator', 'Creator', 50),
+  ('pro', 'Pro', 200)
+ON CONFLICT (id) DO UPDATE
+SET display_name = EXCLUDED.display_name,
+    monthly_credits = EXCLUDED.monthly_credits;
+
+CREATE TABLE IF NOT EXISTS public.user_subscriptions (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL UNIQUE REFERENCES public.users(id) ON DELETE CASCADE,
+  plan TEXT NOT NULL REFERENCES public.subscription_plans(id),
+  status TEXT NOT NULL DEFAULT 'active',
+  stripe_subscription_id TEXT UNIQUE,
+  stripe_customer_id TEXT,
+  current_period_end TIMESTAMPTZ,
+  last_credited_period_start DATE,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+ALTER TABLE public.user_subscriptions ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS user_subscriptions_select_own ON public.user_subscriptions;
+CREATE POLICY user_subscriptions_select_own
+  ON public.user_subscriptions
+  FOR SELECT
+  USING (user_id = auth.uid());
+
+REVOKE ALL ON TABLE public.user_subscriptions FROM PUBLIC;
+GRANT SELECT ON TABLE public.user_subscriptions TO authenticated;
+GRANT SELECT, INSERT, UPDATE ON TABLE public.user_subscriptions TO service_role;
+
+CREATE OR REPLACE FUNCTION public.sync_user_subscription(
+  p_user_id uuid,
+  p_plan text,
+  p_status text,
+  p_stripe_subscription_id text,
+  p_stripe_customer_id text,
+  p_current_period_end bigint
+)
+RETURNS uuid
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_plan text := COALESCE(NULLIF(p_plan, ''), 'starter');
+  v_subscription_id uuid;
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM public.subscription_plans WHERE id = v_plan) THEN
+    v_plan := 'starter';
+  END IF;
+
+  INSERT INTO public.user_subscriptions (
+    user_id,
+    plan,
+    status,
+    stripe_subscription_id,
+    stripe_customer_id,
+    current_period_end,
+    updated_at
+  )
+  VALUES (
+    p_user_id,
+    v_plan,
+    COALESCE(NULLIF(p_status, ''), 'active'),
+    p_stripe_subscription_id,
+    p_stripe_customer_id,
+    CASE WHEN p_current_period_end IS NULL THEN NULL ELSE to_timestamp(p_current_period_end) END,
+    now()
+  )
+  ON CONFLICT (user_id) DO UPDATE
+  SET plan = EXCLUDED.plan,
+      status = EXCLUDED.status,
+      stripe_subscription_id = COALESCE(EXCLUDED.stripe_subscription_id, public.user_subscriptions.stripe_subscription_id),
+      stripe_customer_id = COALESCE(EXCLUDED.stripe_customer_id, public.user_subscriptions.stripe_customer_id),
+      current_period_end = COALESCE(EXCLUDED.current_period_end, public.user_subscriptions.current_period_end),
+      updated_at = now()
+  RETURNING id INTO v_subscription_id;
+
+  RETURN v_subscription_id;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.apply_monthly_subscription_credits(
+  p_user_id uuid
+)
+RETURNS integer
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_plan text;
+  v_credits integer;
+  v_period_start date := date_trunc('month', now())::date;
+  v_last_credited date;
+BEGIN
+  SELECT plan, last_credited_period_start
+  INTO v_plan, v_last_credited
+  FROM public.user_subscriptions
+  WHERE user_id = p_user_id
+    AND status IN ('active', 'trialing', 'past_due')
+  FOR UPDATE;
+
+  IF v_plan IS NULL THEN
+    RETURN 0;
+  END IF;
+
+  IF v_last_credited = v_period_start THEN
+    RETURN 0;
+  END IF;
+
+  SELECT monthly_credits INTO v_credits
+  FROM public.subscription_plans
+  WHERE id = v_plan;
+
+  IF v_credits IS NULL THEN
+    RETURN 0;
+  END IF;
+
+  PERFORM public.add_credits(p_user_id, v_credits);
+
+  UPDATE public.user_subscriptions
+  SET last_credited_period_start = v_period_start,
+      updated_at = now()
+  WHERE user_id = p_user_id;
+
+  RETURN v_credits;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.refresh_monthly_credits()
+RETURNS integer
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_count integer := 0;
+  v_row record;
+BEGIN
+  FOR v_row IN
+    SELECT user_id
+    FROM public.user_subscriptions
+    WHERE status IN ('active', 'trialing', 'past_due')
+  LOOP
+    PERFORM public.apply_monthly_subscription_credits(v_row.user_id);
+    v_count := v_count + 1;
+  END LOOP;
+
+  RETURN v_count;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.sync_user_subscription(uuid, text, text, text, text, bigint) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.apply_monthly_subscription_credits(uuid) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.refresh_monthly_credits() FROM PUBLIC;
+
+GRANT EXECUTE ON FUNCTION public.sync_user_subscription(uuid, text, text, text, text, bigint) TO service_role;
+GRANT EXECUTE ON FUNCTION public.apply_monthly_subscription_credits(uuid) TO service_role;
+GRANT EXECUTE ON FUNCTION public.refresh_monthly_credits() TO service_role;


### PR DESCRIPTION
### Motivation
- Complete Phase 28 by adding the SaaS economic and access control layer so real users can be onboarded and billed for renders. 
- Provide configurable per-render costs, subscription plans, credit issuance, and usage visibility to support a safe public launch.

### Description
- Added a small billing library `apps/web/lib/billing.ts` with plan definitions (`starter`, `creator`, `pro`), `parsePlan`, and `getVideoJobCost()` to make per-render cost configurable via `VIDEO_JOB_COST`.
- Updated job creation to use the configurable `VIDEO_JOB_COST` while preserving server-side RPC-based credit deduction and rate-limit handling in `apps/web/app/api/jobs/create/route.ts`.
- Implemented billing endpoints under `apps/web/app/api/billing/`: `POST /create-checkout-session`, `POST /webhook`, `GET /subscription`, `GET /usage`, and `POST /monthly-reset` to create Stripe checkout sessions, process webhooks, expose subscription state/usage, and trigger the monthly credit refresh.
- Added DB migration `packages/db/migrations/015_phase_28_billing_subscriptions.sql` including `subscription_plans`, `user_subscriptions` and RPCs `sync_user_subscription`, `apply_monthly_subscription_credits`, and `refresh_monthly_credits`; plus a client-side `UsageMetrics` component wired into the dashboard to show plan, remaining credits, and monthly renders used.

### Testing
- Ran `npm run typecheck` for the web workspace and it completed successfully (typecheck passed).
- Started the Next.js dev server (`npx next dev`) which reported as ready and served the app locally, validating compile/runtime startup.
- Attempted an end-to-end screenshot with Playwright, but the Chromium browser process crashed in this environment causing the UI screenshot step to fail.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a940c5553c8331b4d8a0b58e596d45)