### PR TITLE
fix(web): disable prod webpack cache to avoid Cloudflare Pages 25 MiB limit

### DIFF
--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -1,4 +1,15 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {};
+const nextConfig = {
+  webpack: (config, { dev }) => {
+    // Cloudflare Pages has a 25 MiB per-file upload limit.
+    // Disable persistent webpack caching in production so .next/cache/webpack/*.pack
+    // artifacts are not generated and included in deployment output.
+    if (!dev) {
+      config.cache = false;
+    }
+
+    return config;
+  },
+};
 
 export default nextConfig;


### PR DESCRIPTION
### Motivation
- Cloudflare Pages rejects files larger than 25 MiB, and Next.js persistent webpack cache can generate `.next/cache/webpack/*.pack` artifacts that exceed this limit. 
- The goal is to prevent oversized cache artifacts from being produced during production builds so Pages deployments succeed.

### Description
- Updated `apps/web/next.config.mjs` to disable webpack persistent cache in production by setting `config.cache = false` when `dev` is false. 
- Added an inline comment explaining the Cloudflare per-file size constraint and the rationale for the change. 
- Development caching behavior is preserved (the override is production-only).

### Testing
- Ran `npm run build:web`, which compiles successfully but the build fails later while collecting page data due to a missing environment variable `NEXT_PUBLIC_SUPABASE_URL`, which is unrelated to the webpack cache change. 
- Attempted to fetch Cloudflare Pages limits via `curl -L https://developers.cloudflare.com/pages/platform/limits/`, but the network request failed in this environment (HTTP 403 / tunnel failure).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aa5b3bf9a483319d7108bebf39af23)